### PR TITLE
libFuzzer improvements

### DIFF
--- a/services/libfuzzer/Dockerfile
+++ b/services/libfuzzer/Dockerfile
@@ -10,6 +10,7 @@ RUN \
     libpulse0 \
     subversion \
     mercurial \
+    screen \
   && apt-get clean -y \
   && apt-get autoclean -y \
   && apt-get autoremove -y \

--- a/services/libfuzzer/coverage.sh
+++ b/services/libfuzzer/coverage.sh
@@ -17,15 +17,6 @@ then
     chmod -R 755 firefox
 fi
 
-# Download mozilla-central source code.
-# - We might have a volume attached which mounts the source into the container.
-if [[ ! -d "$WORKDIR/mozilla-central" ]]
-then
-    hg clone -r "$REVISION" https://hg.mozilla.org/mozilla-central
-else
-    (cd mozilla-central && hg update -r "$REVISION")
-fi
-
 # Setup required coverage environment variables.
 export COVERAGE=1
 export GCOV_PREFIX_STRIP=6
@@ -42,15 +33,14 @@ grcov "$WORKDIR/firefox" \
     -t coveralls+ \
     --commit-sha "$REVISION" \
     --token NONE \
-    -s "$WORKDIR/mozilla-central" \
     -p $(rg -Nor '$1' "pathprefix = (.*)" "$WORKDIR/firefox/firefox.fuzzmanagerconf") \
     > "$WORKDIR/coverage.json"
 
 # Submit coverage data.
 python -m CovReporter.CovReporter \
     --repository mozilla-central \
-    --description "FuzzOS-LibFuzzer ($FUZZER,rt=$COVRUNTIME)" \
-    --tool "FuzzOS-LibFuzzer-$FUZZER" \
+    --description "libFuzzer ($FUZZER,rt=$COVRUNTIME)" \
+    --tool "libFuzzer-$FUZZER" \
     --submit "$WORKDIR/coverage.json"
 
 # Disable our pool.

--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -66,6 +66,7 @@ then
   fi
 
   # Download the corpus from S3
+  # shellcheck disable=SC2086
   $AFL_LIBFUZZER_DAEMON $CORPUS_DOWNLOAD_ARGS $S3_PROJECT_ARGS --s3-corpus-download corpora/
 elif [ -n "$CORPORA" ]
 then

--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -119,7 +119,7 @@ LIBFUZZER_ARGS=($LIBFUZZER_ARGS $TOKEN $CORPORA)
 # TODO: We need to auto-detect this based on the machine
 if [ -z "$LIBFUZZER_INSTANCES" ]
 then
-  LIBFUZZER_INSTANCES=`nproc`
+  LIBFUZZER_INSTANCES=$(nproc)
 fi
 
 # Support auto reduction, format is "MIN,PERCENT".
@@ -131,10 +131,11 @@ then
 fi
 
 # Run LibFuzzer
+# shellcheck disable=SC2086
 $AFL_LIBFUZZER_DAEMON $S3_PROJECT_ARGS $S3_QUEUE_UPLOAD_ARGS \
   --fuzzmanager \
   --libfuzzer $LIBFUZZER_AUTOREDUCE_ARGS \
-  --libfuzzer-instances $LIBFUZZER_INSTANCES \
+  --libfuzzer-instances "$LIBFUZZER_INSTANCES" \
   --stats "./stats" \
   --sigdir "$HOME/signatures" \
   --tool "libFuzzer-$FUZZER" \

--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -24,6 +24,9 @@ fi
 # FuzzData
 FUZZDATA_URL="https://github.com/mozillasecurity/fuzzdata.git/trunk"
 
+# AFL/LibFuzzer management tool
+AFL_LIBFUZZER_DAEMON="./fuzzmanager/misc/afl-libfuzzer/afl-libfuzzer-daemon.py"
+
 # ContentIPC
 if [ -n "$MOZ_IPC_MESSAGE_FUZZ_BLACKLIST" ]
 then
@@ -32,15 +35,47 @@ then
   export MOZ_IPC_MESSAGE_FUZZ_BLACKLIST="$HOME/$MOZ_IPC_MESSAGE_FUZZ_BLACKLIST"
 fi
 
+S3_PROJECT_ARGS=""
+S3_QUEUE_UPLOAD_ARGS=""
+
 # LibFuzzer Corpora
-if [ -n "$CORPORA" ]
+if [ -n "$S3_PROJECT" ]
 then
+  # Use S3 for corpus management and synchronization. Each instance will download the corpus
+  # from S3 (either by downloading a bundle or by downloading a fraction of files).
+  # Whenever new coverage is found, that file is uploaded to an instance-unique queue on S3
+  # so other instances can download it for sharing progress. When using this, it is important
+  # to have a job on the build server that periodically recombines all open S3 queues
+  # into a new corpus.
+
+  # Generic parameters for S3
+  S3_PROJECT_ARGS="--s3-bucket mozilla-aflfuzz --project $S3_PROJECT"
+
+  # This option ensures that we synchronize local finds from/to S3 queues.
+  # When generating coverage, it does not make sense to use this.
+  if [ -z "$COVERAGE" ]
+  then
+    S3_QUEUE_UPLOAD_ARGS="--s3-queue-upload"
+  fi
+
+  # This can be used to download only a subset of corpus files for fuzzing
+  CORPUS_DOWNLOAD_ARGS=""
+  if [ -n "$S3_CORPUS_SUBSET_SIZE" ]
+  then
+    CORPUS_DOWNLOAD_ARGS="--s3-corpus-download-size $S3_CORPUS_SUBSET_SIZE"
+  fi
+
+  # Download the corpus from S3
+  $AFL_LIBFUZZER_DAEMON $CORPUS_DOWNLOAD_ARGS $S3_PROJECT_ARGS --s3-corpus-download corpora/
+elif [ -n "$CORPORA" ]
+then
+  # Use a static corpus instead
   svn export --force "$FUZZDATA_URL/$CORPORA" ./corpora/
-  CORPORA="./corpora/"
 else
   mkdir ./corpora
-  CORPORA="./corpora/"
 fi
+
+CORPORA="./corpora/"
 
 # LibFuzzer Dictionary Tokens
 if [ -n "$TOKENS" ]
@@ -68,24 +103,41 @@ $ASAN
 # Run reporter for EC2
 tee run-ec2report.sh << EOF
 #!/bin/bash
-./fuzzmanager/EC2Reporter/EC2Reporter.py --report-from-file stats --keep-reporting 60 --random-offset 30
+./fuzzmanager/EC2Reporter/EC2Reporter.py --report-from-file ./stats --keep-reporting 60 --random-offset 30
 EOF
 chmod u+x run-ec2report.sh
-#screen -t ec2report -dmS ec2report ./run-ec2report.sh
+screen -t ec2report -dmS ec2report ./run-ec2report.sh
 
 # Setup LibFuzzer
 export FUZZER="${FUZZER:-SdpParser}"
 export LIBFUZZER=1
 export MOZ_RUN_GTEST=1
 # shellcheck disable=SC2206
-LIBFUZZER_ARGS=("-print_pcs=1" "-handle_segv=0" "-handle_bus=0" "-handle_abrt=0" $LIBFUZZER_ARGS $TOKEN $CORPORA)
+LIBFUZZER_ARGS=($LIBFUZZER_ARGS $TOKEN $CORPORA)
+
+# How many instances to run in parallel
+# TODO: We need to auto-detect this based on the machine
+if [ -z "$LIBFUZZER_INSTANCES" ]
+then
+  LIBFUZZER_INSTANCES=`nproc`
+fi
+
+# Support auto reduction, format is "MIN,PERCENT".
+LIBFUZZER_AUTOREDUCE_ARGS=""
+if [ -n "$LIBFUZZER_AUTOREDUCE" ]
+then
+  IFS=',' read -r -a LIBFUZZER_AUTOREDUCE_PARAMS <<< "$LIBFUZZER_AUTOREDUCE"
+  LIBFUZZER_AUTOREDUCE_ARGS="--libfuzzer-auto-reduce-min ${LIBFUZZER_AUTOREDUCE_PARAMS[0]} --libfuzzer-auto-reduce ${LIBFUZZER_AUTOREDUCE_PARAMS[1]}"
+fi
 
 # Run LibFuzzer
-./fuzzmanager/misc/afl-libfuzzer/afl-libfuzzer-daemon.py \
+$AFL_LIBFUZZER_DAEMON $S3_PROJECT_ARGS $S3_QUEUE_UPLOAD_ARGS \
   --fuzzmanager \
-  --libfuzzer \
+  --libfuzzer $LIBFUZZER_AUTOREDUCE_ARGS \
+  --libfuzzer-instances $LIBFUZZER_INSTANCES \
+  --stats "./stats" \
   --sigdir "$HOME/signatures" \
-  --tool "LibFuzzer-$FUZZER" \
+  --tool "libFuzzer-$FUZZER" \
   --env "ASAN_OPTIONS=${ASAN_OPTIONS//:/ }" \
   --cmd "$HOME/firefox/firefox" "${LIBFUZZER_ARGS[@]}"
 


### PR DESCRIPTION
This PR adds the following features and fixes:

- Add support for S3_PROJECT to obtain corpus from S3 and synchronize files back for progress sharing and corpus evolving
- Add support for running multiple instances, defaulting to number of CPU threads
- Add auto-reduce support
- Add stats support
- Adjust tool name to match naming scheme in the backend
- Remove requirement for having mozilla-central around when generating coverage
- Remove some default options being passed to libFuzzer as the harness passes them already