### PR TITLE
Make the funfuzz Python package able to be run in the Docker, by porting funfuzz.sh

### DIFF
--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -1,0 +1,22 @@
+FROM mozillasecurity/fuzzos:latest
+
+LABEL maintainer Gary Kwong <gkwong@mozilla.com>
+WORKDIR /home/worker/funfuzz
+
+USER root
+COPY recipes /tmp/recipes
+RUN /tmp/recipes/install_prerequisites.sh \
+    && rm -rf /tmp/recipes/install_prerequisites.sh \
+    && chown -R worker:worker /home/worker
+
+ENV USER      worker
+ENV HOME      /home/worker
+ENV LOGNAME   worker
+ENV HOSTNAME  worker
+ENV LANG      en_US.UTF-8
+ENV LC_ALL    en_US.UTF-8
+
+USER $USER
+COPY setup.sh $HOME
+RUN $HOME/setup.sh
+ENTRYPOINT ["/bin/bash", "--login"]

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -29,4 +29,9 @@ ENV PS1="[\u@\h \d \t \W ] $ "
 USER $USER
 COPY setup.sh $HOME
 RUN $HOME/setup.sh
+
+USER root
+RUN "$HOME/.bin/cleanup.sh"
+
+USER $USER
 ENTRYPOINT ["/bin/bash", "--login"]

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -16,6 +16,16 @@ ENV HOSTNAME  worker
 ENV LANG      en_US.UTF-8
 ENV LC_ALL    en_US.UTF-8
 
+ENV PATH="${HOME}/.cargo/bin:${HOME}/.local/bin:${PATH}"
+ENV LD_LIBRARY_PATH=.
+ENV ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+
+# Expand bash shell history length
+ENV HISTTIMEFORMAT="%h %d %H:%M:%S "
+ENV HISTSIZE=10000
+# Modify bash prompt
+ENV PS1="[\u@\h \d \t \W ] $ "
+
 USER $USER
 COPY setup.sh $HOME
 RUN $HOME/setup.sh

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/worker/funfuzz
 USER root
 COPY recipes /tmp/recipes
 RUN /tmp/recipes/install_prerequisites.sh \
-    && rm -rf /tmp/recipes/install_prerequisites.sh \
+    && rm -f /tmp/recipes/install_prerequisites.sh \
     && chown -R worker:worker /home/worker
 
 ENV USER      worker

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /home/worker/funfuzz
 
 USER root
 COPY recipes /tmp/recipes
+
 RUN /tmp/recipes/install_prerequisites.sh \
     && rm -f /tmp/recipes/install_prerequisites.sh \
     && chown -R worker:worker /home/worker

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -28,7 +28,7 @@ ENV PS1="[\u@\h \d \t \W ] $ "
 
 USER $USER
 COPY setup.sh $HOME
-RUN $HOME/setup.sh
+RUN "$HOME/setup.sh"
 
 USER root
 RUN "$HOME/.bin/cleanup.sh"

--- a/services/funfuzz/funfuzz.sh
+++ b/services/funfuzz/funfuzz.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+
+pushd "$HOME"
+
+python3 -u -m funfuzz.loop_bot -b "--random" --target-time 28800 | tee log-loopBotPy.txt
+
+popd

--- a/services/funfuzz/recipes/get_moz_repos.sh
+++ b/services/funfuzz/recipes/get_moz_repos.sh
@@ -10,8 +10,7 @@ function retry {
 
 pushd "$HOME"
 
-HG_FLAGS="retry $HOME/.local/bin/hg "
-
+# HG_FLAGS="retry $HOME/.local/bin/hg "
 # Clone repositories using get_hg_repo.sh
 mkdir -p trees/
 pushd "$HOME/trees/"

--- a/services/funfuzz/recipes/get_moz_repos.sh
+++ b/services/funfuzz/recipes/get_moz_repos.sh
@@ -16,8 +16,8 @@ mkdir -p trees/
 pushd "$HOME/trees/"
 # Note: hg clone works but we may want to switch to other script prior to deployment
 # $HG_FLAGS clone https://hg.mozilla.org/mozilla-central mozilla-central
-# wget -O- https://git.io/fxxh4 | bash -s -- / mozilla-central trees/
-# wget -O- https://git.io/fxxh4 | bash -s -- /releases/ mozilla-beta trees/
+# curl -Ls https://git.io/fxxh4 | bash -s -- / mozilla-central trees/
+# curl -Ls https://git.io/fxxh4 | bash -s -- /releases/ mozilla-beta trees/
 popd
 
 popd

--- a/services/funfuzz/recipes/get_moz_repos.sh
+++ b/services/funfuzz/recipes/get_moz_repos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+function retry {
+  # shellcheck disable=SC2015
+  for _ in {1..9}; do
+    "$@" && return || sleep 30
+  done
+  "$@"
+}
+
+pushd "$HOME"
+
+HG_FLAGS="retry $HOME/.local/bin/hg "
+
+# Clone repositories using get_hg_repo.sh
+mkdir -p trees/
+pushd "$HOME/trees/"
+# Note: hg clone works but we may want to switch to other script prior to deployment
+# $HG_FLAGS clone https://hg.mozilla.org/mozilla-central mozilla-central
+# wget -O- https://git.io/fxxh4 | bash -s -- / mozilla-central trees/
+# wget -O- https://git.io/fxxh4 | bash -s -- /releases/ mozilla-beta trees/
+popd
+
+popd

--- a/services/funfuzz/recipes/get_moz_repos.sh
+++ b/services/funfuzz/recipes/get_moz_repos.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -ex
 
-function retry {
-  # shellcheck disable=SC2015
-  for _ in {1..9}; do
-    "$@" && return || sleep 30
-  done
-  "$@"
-}
+# shellcheck disable=SC1090
+source ~/.common.sh
 
 pushd "$HOME"
 

--- a/services/funfuzz/recipes/get_non_moz_repos.sh
+++ b/services/funfuzz/recipes/get_non_moz_repos.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+function retry {
+  # shellcheck disable=SC2015
+  for _ in {1..9}; do
+    "$@" && return || sleep 30
+  done
+  "$@"
+}
+
+pushd "$HOME"
+
+GITFLAGS="retry git clone -v --depth 1 --no-tags "
+
+$GITFLAGS https://github.com/MozillaSecurity/autobisect autobisect
+$GITFLAGS https://github.com/WebAssembly/binaryen binaryen
+$GITFLAGS https://github.com/MozillaSecurity/ffpuppet ffpuppet
+$GITFLAGS https://github.com/MozillaSecurity/octo octo
+$GITFLAGS https://github.com/MozillaSecurity/funfuzz funfuzz
+# Clone awsm only if the access key is found
+if [[ -f "$HOME/.ssh/id_rsa.fuzz" ]]
+then
+  $GITFLAGS git@framagit.org:bnjbvr/awsm.git awsm
+fi
+
+popd

--- a/services/funfuzz/recipes/get_non_moz_repos.sh
+++ b/services/funfuzz/recipes/get_non_moz_repos.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -ex
 
-function retry {
-  # shellcheck disable=SC2015
-  for _ in {1..9}; do
-    "$@" && return || sleep 30
-  done
-  "$@"
-}
+# shellcheck disable=SC1090
+source ~/.common.sh
 
 pushd "$HOME"
 

--- a/services/funfuzz/recipes/get_pip_packages.sh
+++ b/services/funfuzz/recipes/get_pip_packages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+pushd "$HOME"
+
+# Get more fuzzing prerequisites - have to install as root, else `hg` is not found by the rest of this script
+python2 -m pip install --upgrade pip setuptools virtualenv
+python3 -m pip install --upgrade pip setuptools
+
+# Get supporting fuzzing libraries via pip, funfuzz will be used as the "funfuzz" user later
+pushd "$HOME/funfuzz/"  # For requirements.txt to work properly, we have to be in the repository directory
+python2 -m pip install --user --upgrade mercurial
+python3 -m pip install --user --upgrade future-breakpoint
+python3 -m pip install --user --upgrade -r requirements.txt
+python3 -m pip install --user --upgrade ".[test]"
+popd
+
+popd

--- a/services/funfuzz/recipes/get_rust.sh
+++ b/services/funfuzz/recipes/get_rust.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+function retry {
+  # shellcheck disable=SC2015
+  for _ in {1..9}; do
+    "$@" && return || sleep 30
+  done
+  "$@"
+}
+
+pushd "$HOME"
+
+RUSTUP_FLAGS="retry $HOME/.cargo/bin/rustup "
+RUSTC_FLAGS="retry $HOME/.cargo/bin/rustc "
+
+# Install Rust using rustup
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+$RUSTUP_FLAGS update stable
+$RUSTUP_FLAGS target add i686-unknown-linux-gnu
+$RUSTUP_FLAGS --version
+$RUSTC_FLAGS --version
+
+popd

--- a/services/funfuzz/recipes/get_rust.sh
+++ b/services/funfuzz/recipes/get_rust.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -ex
 
-function retry {
-  # shellcheck disable=SC2015
-  for _ in {1..9}; do
-    "$@" && return || sleep 30
-  done
-  "$@"
-}
+# shellcheck disable=SC1090
+source ~/.common.sh
 
 pushd "$HOME"
 

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -42,3 +42,15 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     aria2 \
     screen \
     vim
+
+rm -rf /usr/share/man/ /usr/share/info/
+
+find /usr/share/doc -depth -type f ! -name copyright -exec rm {} + || true
+find /usr/share/doc -empty -exec rmdir {} + || true
+
+apt-get clean -y
+apt-get autoclean -y
+apt-get autoremove -y
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /root/.cache/*

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -42,15 +42,3 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     aria2 \
     screen \
     vim
-
-rm -rf /usr/share/man/ /usr/share/info/
-
-find /usr/share/doc -depth -type f ! -name copyright -exec rm {} + || true
-find /usr/share/doc -empty -exec rmdir {} + || true
-
-apt-get clean -y
-apt-get autoclean -y
-apt-get autoremove -y
-
-rm -rf /var/lib/apt/lists/*
-rm -rf /root/.cache/*

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -44,7 +44,6 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
 apt-get install -q -y --no-install-recommends --no-install-suggests \
     aria2 \
     screen \
-    sudo \
     vim
 
 rm -rf /usr/share/man/ /usr/share/info/

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
-locale-gen en_US.UTF-8
-
 apt-get update -y -qq
 # Required to use apt-key
 apt-get install -q -y --no-install-recommends --no-install-suggests dirmngr

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -45,8 +45,7 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     aria2 \
     screen \
     sudo \
-    vim \
-    wget
+    vim
 
 rm -rf /usr/share/man/ /usr/share/info/
 

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -1,0 +1,61 @@
+#!/bin/bash -ex
+
+echo "en_US.UTF-8 UTF-8" > /etc/locale.gen
+locale-gen en_US.UTF-8
+
+apt-get update -y -qq
+# Required to use apt-key
+apt-get install -q -y --no-install-recommends --no-install-suggests dirmngr
+
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8B48AD6246925553
+echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list
+
+apt-get update -y -qq
+
+# Prior to deployment, check that apt-get requirements are also installed via other recipes in FuzzOS, e.g. ccache
+# Check using `hg --cwd ~/trees/mozilla-central/ diff -r edf1f05e9d00:ad6f51d4af0b python/mozboot/mozboot/debian.py`
+# Retrieved on 2018-12-26: https://hg.mozilla.org/mozilla-central/file/ad6f51d4af0b/python/mozboot/mozboot/debian.py
+apt-get install -q -y --no-install-recommends --no-install-suggests \
+    apache2-utils \
+    autoconf2.13 \
+    build-essential \
+    libasound2-dev \
+    libcurl4-openssl-dev \
+    libdbus-1-dev \
+    libdbus-glib-1-dev \
+    libgconf2-dev \
+    libgtk-3-dev \
+    libgtk2.0-dev \
+    libpulse-dev \
+    libx11-xcb-dev \
+    libxt-dev \
+    nasm \
+    python-dbus \
+    python-dev \
+    uuid \
+    yasm \
+    zip
+
+apt-get install -q -y --no-install-recommends --no-install-suggests \
+    lib32z1 \
+    libc6-dbg \
+    valgrind
+
+apt-get install -q -y --no-install-recommends --no-install-suggests \
+    aria2 \
+    screen \
+    sudo \
+    vim \
+    wget
+
+rm -rf /usr/share/man/ /usr/share/info/
+
+find /usr/share/doc -depth -type f ! -name copyright -exec rm {} + || true
+find /usr/share/doc -empty -exec rmdir {} + || true
+
+apt-get clean -y
+apt-get autoclean -y
+apt-get autoremove -y
+
+rm -rf /var/lib/apt/lists/*
+rm -rf /root/.cache/*

--- a/services/funfuzz/recipes/set_bashrc_options.sh
+++ b/services/funfuzz/recipes/set_bashrc_options.sh
@@ -6,18 +6,6 @@ cat << EOF >> .bashrc
 
 ulimit -c unlimited
 
-# Expand bash shell history length
-export HISTTIMEFORMAT="%h %d %H:%M:%S "
-HISTSIZE=10000
-
-# Modify bash prompt
-export PS1="[\u@\h \d \t \W ] $ "
-
-export LD_LIBRARY_PATH=.
-export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
-
-PATH=/home/worker/.cargo/bin:/home/worker/.local/bin:$PATH
-
 ccache -M 12G
 EOF
 

--- a/services/funfuzz/recipes/set_bashrc_options.sh
+++ b/services/funfuzz/recipes/set_bashrc_options.sh
@@ -2,7 +2,7 @@
 
 pushd "$HOME"
 
-cat << 'EOF' >> .bashrc
+cat << EOF >> .bashrc
 
 ulimit -c unlimited
 

--- a/services/funfuzz/recipes/set_bashrc_options.sh
+++ b/services/funfuzz/recipes/set_bashrc_options.sh
@@ -2,7 +2,7 @@
 
 pushd "$HOME"
 
-cat << EOF >> .bashrc
+cat << 'EOF' >> .bashrc
 
 ulimit -c unlimited
 

--- a/services/funfuzz/recipes/set_bashrc_options.sh
+++ b/services/funfuzz/recipes/set_bashrc_options.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+pushd "$HOME"
+
+cat << EOF >> .bashrc
+
+ulimit -c unlimited
+
+# Expand bash shell history length
+export HISTTIMEFORMAT="%h %d %H:%M:%S "
+HISTSIZE=10000
+
+# Modify bash prompt
+export PS1="[\u@\h \d \t \W ] $ "
+
+export LD_LIBRARY_PATH=.
+export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
+
+PATH=/home/worker/.cargo/bin:/home/worker/.local/bin:$PATH
+
+ccache -M 12G
+EOF
+
+popd

--- a/services/funfuzz/recipes/set_mercurial_config.sh
+++ b/services/funfuzz/recipes/set_mercurial_config.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+pushd "$HOME"
+
+# Populate Mercurial settings.
+cat << EOF > .hgrc
+[ui]
+merge = internal:merge
+ssh = ssh -C -v
+
+[extensions]
+mq =
+progress =
+purge =
+rebase =
+EOF
+
+popd

--- a/services/funfuzz/recipes/set_vim_config.sh
+++ b/services/funfuzz/recipes/set_vim_config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+
+pushd "$HOME"
+
+# Add vimrc for Bionic
+cat << EOF > .vimrc
+:syntax enable
+syntax on
+set number
+set ruler
+set nocompatible
+set bs=2
+fixdel
+set nowrap
+set tabstop=4
+set autoindent
+set term=xterm
+set smartindent
+set showmode showcmd
+set shiftwidth=4
+set expandtab
+set backspace=indent,eol,start
+set hls
+au BufNewFile,BufRead *.* exec 'match Error /\%119v/'
+set paste
+EOF
+
+popd

--- a/services/funfuzz/recipes/ssh_fuzzmanager_setup.sh
+++ b/services/funfuzz/recipes/ssh_fuzzmanager_setup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -ex
+
+function retry {
+  # shellcheck disable=SC2015
+  for _ in {1..9}; do
+    "$@" && return || sleep 30
+  done
+  "$@"
+}
+
+eval "$(ssh-agent -s)"
+mkdir -p .ssh
+retry ssh-keyscan github.com >> .ssh/known_hosts
+
+# Figure this out before deployment
+# # Get deployment keys from credstash
+# if [[ -f "$HOME/.aws/credentials" ]]
+# then
+#   retry credstash get funfuzz-gkw-key > .ssh/gkwAWSFuzz.pem
+#   chmod 0600 .ssh/gkwAWSFuzz.pem
+#   retry credstash get awsm-gkw-key > .ssh/id_rsa.fuzz
+#   chmod 0600 .ssh/id_rsa.fuzz
+# fi
+
+# # Get FuzzManager configuration from credstash.
+# # We require FuzzManager credentials in order to submit our results.
+# if [[ ! -f "$HOME/.fuzzmanagerconf" ]]
+# then
+#   retry credstash get fuzzmanagerconf > .fuzzmanagerconf
+# fi
+
+# Update FuzzManager config for this instance.
+mkdir -p sigcache
+cat >> .fuzzmanagerconf << EOF
+sigdir = $HOME/sigcache
+tool = funfuzz
+EOF
+
+# Setup Additional Key Identities
+cat << EOF >> .ssh/config
+Host *
+StrictHostKeyChecking no
+
+Host funfuzz
+HostName github.com
+IdentitiesOnly yes
+IdentityFile ~/.ssh/gkwAWSFuzz.pem
+
+Host framagit.org
+IdentityFile ~/.ssh/id_rsa.fuzz
+User nth10sd
+EOF

--- a/services/funfuzz/recipes/ssh_fuzzmanager_setup.sh
+++ b/services/funfuzz/recipes/ssh_fuzzmanager_setup.sh
@@ -1,12 +1,7 @@
 #!/bin/bash -ex
 
-function retry {
-  # shellcheck disable=SC2015
-  for _ in {1..9}; do
-    "$@" && return || sleep 30
-  done
-  "$@"
-}
+# shellcheck disable=SC1090
+source ~/.common.sh
 
 eval "$(ssh-agent -s)"
 mkdir -p .ssh

--- a/services/funfuzz/setup.sh
+++ b/services/funfuzz/setup.sh
@@ -12,4 +12,6 @@ pushd "/tmp"
 ./recipes/set_bashrc_options.sh
 # Note: set core file options on host prior to deployment
 
+"$HOME/.bin/cleanup.sh"
+
 popd

--- a/services/funfuzz/setup.sh
+++ b/services/funfuzz/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+pushd "/tmp"
+
+./recipes/ssh_fuzzmanager_setup.sh
+./recipes/get_rust.sh
+./recipes/get_non_moz_repos.sh
+./recipes/get_pip_packages.sh
+./recipes/set_mercurial_config.sh
+./recipes/set_vim_config.sh
+./recipes/get_moz_repos.sh
+./recipes/set_bashrc_options.sh
+# Note: set core file options on host prior to deployment
+
+popd

--- a/services/funfuzz/setup.sh
+++ b/services/funfuzz/setup.sh
@@ -12,6 +12,4 @@ pushd "/tmp"
 ./recipes/set_bashrc_options.sh
 # Note: set core file options on host prior to deployment
 
-"$HOME/.bin/cleanup.sh"
-
 popd

--- a/services/funfuzz/tests/funfuzz_command_test.yaml
+++ b/services/funfuzz/tests/funfuzz_command_test.yaml
@@ -7,4 +7,4 @@ commandTests:
     command: "python3"
     args: ["-m", "funfuzz", "--version"]
     expectedOutput: ["no such option"]
-    exitCode: 2
+    exitCode: 1

--- a/services/funfuzz/tests/funfuzz_command_test.yaml
+++ b/services/funfuzz/tests/funfuzz_command_test.yaml
@@ -1,0 +1,10 @@
+schemaVersion: "2.0.0"
+
+# Basic checks to make sure the application is installed and able to run.
+
+commandTests:
+  - name: "funfuzz installation"
+    command: "python3"
+    args: ["-m", "funfuzz", "--version"]
+    expectedOutput: ["no such option"]
+    exitCode: 2

--- a/services/funfuzz/tests/funfuzz_command_test.yaml
+++ b/services/funfuzz/tests/funfuzz_command_test.yaml
@@ -6,5 +6,5 @@ commandTests:
   - name: "funfuzz installation"
     command: "python3"
     args: ["-m", "funfuzz", "--version"]
-    expectedOutput: ["no such option"]
-    exitCode: 1
+    expectedOutput: ["hg info: Mercurial Distributed SCM"]
+    exitCode: 2

--- a/services/funfuzz/tests/funfuzz_metadata_test.yaml
+++ b/services/funfuzz/tests/funfuzz_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: "2.0.0"
 
 metadataTest:
-  entrypoint: ["/bin/bash"]
-  cmd: ["--login"]
+  entrypoint: ["/bin/bash", "--login"]
+  cmd: []
   workdir: /home/worker/funfuzz

--- a/services/funfuzz/tests/funfuzz_metadata_test.yaml
+++ b/services/funfuzz/tests/funfuzz_metadata_test.yaml
@@ -1,0 +1,6 @@
+schemaVersion: "2.0.0"
+
+metadataTest:
+  entrypoint: ["python3"]
+  cmd: ["-m", "funfuzz", "--version"]
+  workdir: /home/funfuzz/funfuzz

--- a/services/funfuzz/tests/funfuzz_metadata_test.yaml
+++ b/services/funfuzz/tests/funfuzz_metadata_test.yaml
@@ -1,6 +1,6 @@
 schemaVersion: "2.0.0"
 
 metadataTest:
-  entrypoint: ["python3"]
-  cmd: ["-m", "funfuzz", "--version"]
-  workdir: /home/funfuzz/funfuzz
+  entrypoint: ["/bin/bash"]
+  cmd: ["--login"]
+  workdir: /home/worker/funfuzz


### PR DESCRIPTION
Here's the port of funfuzz.sh to Orion with the following output

```
$ docker run -it --rm mozillasecurity/funfuzz:latest
bash: ccache: command not found
$ python3 -u -m funfuzz --version
Platform details: Linux 8fe850dce50a 4.15.0-43-generic #46-Ubuntu SMP Thu Dec 6 14:45:28 UTC 2018 x86_64 x86_64
hg info: Mercurial Distributed SCM (version 4.8.1)
git info: git version 2.17.1
Python version: 3.6.7
Number of cores visible to OS: 4
Free space (GB): 59.11
Corefile size (soft limit, hard limit) is: (-1, -1)
Usage: __main__.py [options]

__main__.py: error: no such option: --version
$
```

As can be seen, funfuzz is installed and can be run after the docker initialises. There is a bunch of issues to be looked into prior to deployment though, e.g. why `ccache` is not found/installed even though we clearly import from FuzzOS. Any ideas?

Thanks a lot for your help earlier this month! Other priorities are coming up so actual deployment may be pushed off some number of quarters.