### PR TITLE
[credstash] Add libssl so `credstash get` works

### DIFF
--- a/services/credstash/Dockerfile
+++ b/services/credstash/Dockerfile
@@ -4,22 +4,23 @@ LABEL maintainer Christoph Diehl <cdiehl@mozilla.com>
 
 RUN apk --no-cache add \
         python3 \
-    && apk --no-cache add --virtual \
-        build-deps \
+    && apk --no-cache add \
         build-base \
         libressl-dev \
         libffi-dev \
         python3-dev \
     && pip3 install --upgrade pip wheel \
-    && pip3 wheel --wheel-dir=/root/wheels credstash \
-    && apk del build-deps
+    && pip3 wheel --wheel-dir=/root/wheels credstash
 
 FROM alpine:latest
 
 COPY --from=builder /root/wheels /root/wheels
 
-RUN apk add --no-cache python3 \
-    && pip3 install --no-index --find-links=/root/wheels credstash \ 
-    && rm -rf /root/wheels
+RUN apk add --no-cache python3 libressl \
+    && pip3 install --no-index --find-links=/root/wheels credstash \
+    && rm -rf /root/wheels \
+    && python3 -m compileall -b -q /usr/lib \
+    && find /usr/lib -name \*.py -delete \
+    && find /usr/lib -name __pycache__ -exec rm -rf \{\} +
 
 ENTRYPOINT ["python3", "-m", "credstash"]


### PR DESCRIPTION
This also pre-compiles python libs to reduce the final image size. (119Mb -> 86Mb).

I removed the clean-up step from the builder too. It's a temporary image anyways, so it just seems like extra work.

Fixes #33.