### PR TITLE
Add Berglas for secrets storage in GCP

### DIFF
--- a/base/linux/fuzzos/README.md
+++ b/base/linux/fuzzos/README.md
@@ -10,21 +10,22 @@ OS: Ubuntu 18.04
 
 | Program     | Version |
 | ----------- | ------- |
+| berglas     |         |
+| breakpad    |         |
 | credstash   |         |
 | fuzzfetch   |         |
 | fuzzmanager |         |
-| honggfuzz   |         |
-| halfempty   |         |
-| llvm 8      | 8       |
-| breakpad    |         |
-| rr          |         |
-| grcov       |         |
-| ripgrep     |         |
-| nodejs      |         |
-| nano        |         |
-| python      | 3       |
-| ssh         |         |
 | git         |         |
+| grcov       |         |
+| halfempty   |         |
+| honggfuzz   |         |
+| llvm        | 8       |
+| nano        |         |
+| nodejs      |         |
+| python      | 3       |
+| ripgrep     |         |
+| rr          |         |
+| ssh         |         |
 
 ## Run
 

--- a/base/linux/fuzzos/recipes/berglas.sh
+++ b/base/linux/fuzzos/recipes/berglas.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+
+#### Install Berglas secrets management tool for GCP
+# https://github.com/GoogleCloudPlatform/berglas
+
+curl -L https://storage.googleapis.com/berglas/master/linux_amd64/berglas -o /usr/local/bin/berglas
+chmod +x /usr/local/bin/berglas

--- a/base/linux/fuzzos/setup.sh
+++ b/base/linux/fuzzos/setup.sh
@@ -45,5 +45,6 @@ cd recipes
 ./rr.sh
 ./grcov.sh
 ./halfempty.sh
+./berglas.sh
 
 ./cleanup.sh


### PR DESCRIPTION
[Berglas](https://github.com/GoogleCloudPlatform/berglas) looks like the best equivalent for credstash in GCP. I've already set it up and it works fine. The pre-compiled binary is statically linked and 11Mb.