### PR TITLE
[ci] Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - docker-ce
       - python3
       - python3-pip
+      - python3-setuptools
 
 git:
   depth: 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 language: generic
 
+dist: bionic
+
 services:
   - docker
 

--- a/base/linux/fuzzos/recipes/fuzzfetch.sh
+++ b/base/linux/fuzzos/recipes/fuzzfetch.sh
@@ -8,4 +8,5 @@ set -x
 
 #### Install FuzzFetch
 
+# >= 0.9.2
 pip3 install git+https://github.com/mozillasecurity/fuzzfetch

--- a/base/linux/fuzzos/recipes/grcov.sh
+++ b/base/linux/fuzzos/recipes/grcov.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 #### Install grcov

--- a/base/linux/fuzzos/recipes/halfempty.sh
+++ b/base/linux/fuzzos/recipes/halfempty.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 #### Install halfempty

--- a/base/linux/fuzzos/recipes/honggfuzz.sh
+++ b/base/linux/fuzzos/recipes/honggfuzz.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 #### Install Honggfuzz

--- a/base/linux/fuzzos/recipes/htop.sh
+++ b/base/linux/fuzzos/recipes/htop.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 

--- a/base/linux/fuzzos/recipes/rg.sh
+++ b/base/linux/fuzzos/recipes/rg.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 #### Install rg (ripgrep)

--- a/base/linux/fuzzos/recipes/rr.sh
+++ b/base/linux/fuzzos/recipes/rr.sh
@@ -6,7 +6,7 @@
 set -e
 set -x
 
-# shellcheck source=base/fuzzos/recipes/common.sh
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
 source "${0%/*}/common.sh"
 
 #### Install rr

--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -119,10 +119,10 @@ then
   mkdir -p ./corpora
   ./oss-fuzz/infra/helper.py download_corpora --fuzz-target "$FUZZER" "$OSSFUZZ_PROJECT" || true
   CORPORA_PATH="./oss-fuzz/build/corpus/$OSSFUZZ_PROJECT/$FUZZER"
-  if [ -d $CORPORA_PATH ]
+  if [ -d "$CORPORA_PATH" ]
   then
     set +x
-    cp $CORPORA_PATH/* ./corpora/ || true
+    cp "$CORPORA_PATH"/* ./corpora/ || true
     set -x
   fi
 elif [ -n "$CORPORA" ]


### PR DESCRIPTION
Fixes setup failure
```
$ travis_retry sudo pip3 install -r requirements.txt
Collecting pyyaml>=4.2b1 (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/e3/e8/b3212641ee2718d556df0f23f78de8303f068fe29cdaa7a91018849582fe/PyYAML-5.1.2.tar.gz (265kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named 'setuptools'
```