### PR TITLE
Update funfuzz scripts in Orion for 201912.

### DIFF
--- a/base/linux/fuzzos/recipes/pernosco_submit.sh
+++ b/base/linux/fuzzos/recipes/pernosco_submit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
+source "${0%/*}/common.sh"
+
+#### Install pernosco-submit
+
+apt-install-auto \
+  zstd
+
+git clone --depth 1 --no-tags https://github.com/Pernosco/pernosco-submit.git
+
+pip3 install awscli

--- a/base/linux/fuzzos/recipes/pernosco_submit.sh
+++ b/base/linux/fuzzos/recipes/pernosco_submit.sh
@@ -11,9 +11,10 @@ source "${0%/*}/common.sh"
 
 #### Install pernosco-submit
 
-apt-install-auto \
+sys-embed \
   zstd
 
-git clone --depth 1 --no-tags https://github.com/Pernosco/pernosco-submit.git
+curl -L "https://raw.githubusercontent.com/Pernosco/pernosco-submit/master/pernosco-submit" > /usr/local/bin/pernosco-submit
+chmod +x /usr/local/bin/pernosco-submit
 
 pip3 install awscli

--- a/services/funfuzz/recipes/get_pip_packages.sh
+++ b/services/funfuzz/recipes/get_pip_packages.sh
@@ -12,7 +12,7 @@ python3 -m pip install --upgrade pip setuptools
 # Get supporting fuzzing libraries via pip, funfuzz will be used as the "funfuzz" user later
 pushd "$HOME/funfuzz/"  # For requirements.txt to work properly, we have to be in the repository directory
 python2 -m pip install --user --upgrade mercurial
-python3 -m pip install --user --upgrade future-breakpoint
+python3 -m pip install --user --upgrade future-breakpoint jsbeautifier gnureadline
 python3 -m pip install --user --upgrade -r requirements.txt
 python3 -m pip install --user --upgrade ".[test]"
 popd

--- a/services/funfuzz/recipes/get_pip_packages.sh
+++ b/services/funfuzz/recipes/get_pip_packages.sh
@@ -12,7 +12,7 @@ python3 -m pip install --upgrade pip setuptools
 # Get supporting fuzzing libraries via pip, funfuzz will be used as the "funfuzz" user later
 pushd "$HOME/funfuzz/"  # For requirements.txt to work properly, we have to be in the repository directory
 python2 -m pip install --user --upgrade mercurial
-python3 -m pip install --user --upgrade future-breakpoint jsbeautifier gnureadline
+python3 -m pip install --user --upgrade future-breakpoint jsbeautifier
 python3 -m pip install --user --upgrade -r requirements.txt
 python3 -m pip install --user --upgrade ".[test]"
 popd

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -3,21 +3,21 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-apt-get update -y -qq
+sys-update
 # Required to use apt-key
-apt-get install -q -y --no-install-recommends --no-install-suggests dirmngr
+sys-embed dirmngr
 
 apt-key adv --recv-key --keyserver keyserver.ubuntu.com \
     8B48AD6246925553 \
     7638D0442B90D010 \
     04EE7237B7D453EC
 echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list
-apt-get update -y -qq
+sys-update
 
 # Prior to deployment, check that apt-get requirements are also installed via other recipes in FuzzOS, e.g. ccache
 # Check using `hg --cwd ~/trees/mozilla-central/ diff -r 95ad10e13fb1:0f6958f49842 python/mozboot/mozboot/debian.py`
 # Retrieved on 2019-12-12: https://hg.mozilla.org/mozilla-central/file/0f6958f49842/python/mozboot/mozboot/debian.py
-apt-get install -q -y --no-install-recommends --no-install-suggests \
+sys-embed \
     apache2-utils \
     autoconf2.13 \
     build-essential \
@@ -37,11 +37,11 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     yasm \
     zip
 
-apt-get install -q -y --no-install-recommends --no-install-suggests \
+sys-embed \
     libc6-dbg \
     valgrind
 
-apt-get install -q -y --no-install-recommends --no-install-suggests \
+sys-embed \
     aria2 \
     screen \
     vim

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -15,8 +15,8 @@ echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc
 apt-get update -y -qq
 
 # Prior to deployment, check that apt-get requirements are also installed via other recipes in FuzzOS, e.g. ccache
-# Check using `hg --cwd ~/trees/mozilla-central/ diff -r edf1f05e9d00:ad6f51d4af0b python/mozboot/mozboot/debian.py`
-# Retrieved on 2018-12-26: https://hg.mozilla.org/mozilla-central/file/ad6f51d4af0b/python/mozboot/mozboot/debian.py
+# Check using `hg --cwd ~/trees/mozilla-central/ diff -r 95ad10e13fb1:0f6958f49842 python/mozboot/mozboot/debian.py`
+# Retrieved on 2019-12-12: https://hg.mozilla.org/mozilla-central/file/0f6958f49842/python/mozboot/mozboot/debian.py
 apt-get install -q -y --no-install-recommends --no-install-suggests \
     apache2-utils \
     autoconf2.13 \
@@ -25,7 +25,6 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     libcurl4-openssl-dev \
     libdbus-1-dev \
     libdbus-glib-1-dev \
-    libgconf2-dev \
     libgtk-3-dev \
     libgtk2.0-dev \
     libpulse-dev \
@@ -39,7 +38,6 @@ apt-get install -q -y --no-install-recommends --no-install-suggests \
     zip
 
 apt-get install -q -y --no-install-recommends --no-install-suggests \
-    lib32z1 \
     libc6-dbg \
     valgrind
 

--- a/services/funfuzz/recipes/install_prerequisites.sh
+++ b/services/funfuzz/recipes/install_prerequisites.sh
@@ -43,5 +43,6 @@ sys-embed \
 
 sys-embed \
     aria2 \
+    libnspr4 \
     screen \
     vim

--- a/services/funfuzz/recipes/set_mercurial_config.sh
+++ b/services/funfuzz/recipes/set_mercurial_config.sh
@@ -8,7 +8,7 @@ pushd "$HOME"
 # Populate Mercurial settings.
 cat << EOF > .hgrc
 [ui]
-username = gkw
+username = funfuzz
 merge = internal:merge
 ssh = ssh -C -v
 

--- a/services/funfuzz/recipes/set_mercurial_config.sh
+++ b/services/funfuzz/recipes/set_mercurial_config.sh
@@ -8,6 +8,7 @@ pushd "$HOME"
 # Populate Mercurial settings.
 cat << EOF > .hgrc
 [ui]
+username = gkw
 merge = internal:merge
 ssh = ssh -C -v
 


### PR DESCRIPTION
Here are the updates for funfuzz setup scripts since the last attempt. We'll need at least these minimal changes before it is attempted to switchover to Orion fully.