### PR TITLE
[grizzly] Install and use launcher for Taskcluster tasks.

### DIFF
--- a/services/grizzly/Dockerfile
+++ b/services/grizzly/Dockerfile
@@ -14,4 +14,5 @@ COPY screenlog-to-cloudwatch.py /usr/local/bin/
 COPY launch-grizzly.sh /home/worker/
 COPY launch-grizzly-worker.sh /home/worker/
 
+ENTRYPOINT ["/usr/local/bin/fuzzing-pool-launch"]
 CMD ["/home/worker/launch-grizzly.sh"]

--- a/services/grizzly/launch-grizzly-worker.sh
+++ b/services/grizzly/launch-grizzly-worker.sh
@@ -18,7 +18,7 @@ if [[ "$EC2SPOTMANAGER_PROVIDER" = "GCE" ]]; then
   mkdir -p .aws
   retry berglas access fuzzmanager-cluster-secrets/credstash-aws-auth > .aws/credentials
   chmod 0600 .aws/credentials
-elif [[ "$TASKCLUSTER_PROXY_URL" != "" ]]; then
+elif [[ -n "$TASKCLUSTER_PROXY_URL" ]]; then
   mkdir -p .aws
   curl -L "$TASKCLUSTER_PROXY_URL/secrets/v1/secret/project/fuzzing/credstash-aws-auth" | python -c 'import json, sys; a = json.load(sys.stdin); open(".aws/credentials", "w").write(a["secret"]["key"])' &&
   chmod 0600 .aws/credentials

--- a/services/grizzly/launch-grizzly.sh
+++ b/services/grizzly/launch-grizzly.sh
@@ -10,7 +10,7 @@ su worker -c /home/worker/launch-grizzly-worker.sh
 
 # need to keep the container running
 while true; do
-  if [[ -n "$EC2SPOTMANAGER_PROVIDER" ]]; then
+  if [[ -n "$EC2SPOTMANAGER_PROVIDER" || -n "$TASKCLUSTER_PROXY_URL" ]]; then
     # this will fail if we aren't in the cloud
     /usr/local/bin/screenlog-to-cloudwatch.py || true
   fi

--- a/services/grizzly/recipes/fuzzing_tc.sh
+++ b/services/grizzly/recipes/fuzzing_tc.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+
+# shellcheck source=base/linux/fuzzos/recipes/common.sh
+source ~/.common.sh
+
+retry python3 -m pip install git+https://github.com/MozillaSecurity/fuzzing-tc

--- a/services/grizzly/recipes/setup.sh
+++ b/services/grizzly/recipes/setup.sh
@@ -86,6 +86,7 @@ if [ ${#dbgsym_installs[@]} -ne 0 ]; then
 fi
 
 /tmp/recipes/redis.sh
+/tmp/recipes/fuzzing_tc.sh
 /tmp/recipes/cloudwatch.sh
 
 retry python3 -m pip install \


### PR DESCRIPTION
If environment variables are set by Taskcluster, environment variables will be fetched and set from the fuzzing config repo.

Depends on https://github.com/MozillaSecurity/fuzzing-tc/pull/37