### PR TITLE
Use gcov-7 from Mozilla Build Server

### DIFF
--- a/recipes/linux/gcov-7.sh
+++ b/recipes/linux/gcov-7.sh
@@ -10,11 +10,11 @@ set -o pipefail
 # shellcheck source=recipes/linux/common.sh
 source "${0%/*}/common.sh"
 
-#### Install gcov-8
+#### Install gcov-7
 
 apt-install-auto \
     ca-certificates \
     curl
 
-curl --retry 5 -sL "https://build.fuzzing.mozilla.org/builds/gcov-8" -o /usr/local/bin/gcov-8
-chmod +x /usr/local/bin/gcov-8
+curl --retry 5 -sL "https://build.fuzzing.mozilla.org/builds/gcov-7" -o /usr/local/bin/gcov-7
+chmod +x /usr/local/bin/gcov-7

--- a/recipes/linux/gcov-8.sh
+++ b/recipes/linux/gcov-8.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+set -o pipefail
+
+# shellcheck source=recipes/linux/common.sh
+source "${0%/*}/common.sh"
+
+#### Install gcov-8
+
+apt-install-auto \
+    ca-certificates \
+    curl
+
+curl --retry 5 -sL "https://build.fuzzing.mozilla.org/builds/gcov-8" -o /usr/local/bin/gcov-8
+chmod +x /usr/local/bin/gcov-8

--- a/services/grizzly/launch-grizzly-worker.sh
+++ b/services/grizzly/launch-grizzly-worker.sh
@@ -68,6 +68,8 @@ pip3 install --user -U -e ./bearspray
 
 update_ec2_status "Setup: launching bearspray"
 
+export GCOV=/usr/local/bin/gcov-7
+
 screen -dmLS grizzly /bin/bash
 sleep 5
 screen -S grizzly -X screen rwait run "$wait_token" python3 -m bearspray --screen --xvfb

--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -32,6 +32,7 @@ cd "${0%/*}"
 ./rg.sh
 ./rr.sh
 ./gcov-7.sh
+./gcov-8.sh
 
 # shellcheck source=recipes/linux/dbgsyms.sh
 source ./dbgsyms.sh

--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -31,7 +31,7 @@ cd "${0%/*}"
 ./redis.sh
 ./rg.sh
 ./rr.sh
-./gcov-8.sh
+./gcov-7.sh
 
 # shellcheck source=recipes/linux/dbgsyms.sh
 source ./dbgsyms.sh


### PR DESCRIPTION
The Ubuntu version of gcov is once again causing issues with grcov.  This PR downloads and installs gcov-8 from the Mozilla build server and uses that when running grcov.