### PR TITLE
Update fuzzfetch gtest arguments

### DIFF
--- a/services/libfuzzer/README.md
+++ b/services/libfuzzer/README.md
@@ -6,7 +6,7 @@ The production Dockerfile uses credstash to fetch credentials for our private Fu
 
 ```bash
 REVISION=$(curl -sL https://build.fuzzing.mozilla.org/builds/coverage-revision.txt)
-fuzzfetch --build "$REVISION" --fuzzing --coverage -a --tests gtest -n firefox
+fuzzfetch --build "$REVISION" --fuzzing --coverage -a --gtest -n firefox
 
 docker run \
     -h `hostname` \
@@ -26,7 +26,7 @@ It is recommended to reserve at least 4GB of memory for containers running cover
 ### Example: LibFuzzer Run
 
 ```bash
-fuzzfetch --fuzzing --coverage -a --tests gtest -n firefox
+fuzzfetch --fuzzing --coverage -a --gtest -n firefox
 
 docker run \
     -h `hostname` \

--- a/services/libfuzzer/setup-target.sh
+++ b/services/libfuzzer/setup-target.sh
@@ -41,7 +41,7 @@ else
   TARGET_BIN="firefox/firefox"
   if [[ ! -d "$HOME/firefox" ]]
   then
-    retry fuzzfetch -n firefox --tests gtest "${FETCH_ARGS[@]}"
+    retry fuzzfetch -n firefox --gtest "${FETCH_ARGS[@]}"
   fi
   chmod -R 0755 "$HOME/firefox"
 fi


### PR DESCRIPTION
Fuzzfetch args `--tests gtest` has been changed to `--gtest` in https://github.com/MozillaSecurity/fuzzfetch/pull/69