### PR TITLE
Add pulseaudio to Grizzly and libfuzzer

### DIFF
--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -45,8 +45,7 @@ packages=(
   libdbus-glib-1-2
   libglu1-mesa
   libosmesa6
-  libpulse0
-  p7zip-full
+  pulseaudio
   python3-wheel
   screen
   subversion

--- a/services/libfuzzer/setup.sh
+++ b/services/libfuzzer/setup.sh
@@ -44,6 +44,7 @@ packages=(
   locales
   nano
   openssh-client
+  pulseaudio
   screen
   software-properties-common
   unzip


### PR DESCRIPTION
Without pulseaudio installed in some cases we see hundreds of processes spawn, attempt to exec /usr/bin/pulseaudio, fail with ENOENT, and then exit. This makes rr traces incompatible with Pernosco.