### PR TITLE
Use fuzzing-decision from the tree, instead of cloning from github

### DIFF
--- a/base/linux/etc/pip.conf
+++ b/base/linux/etc/pip.conf
@@ -7,3 +7,4 @@ format = columns
 
 [install]
 upgrade-strategy = only-if-needed
+progress-bar = off

--- a/recipes/linux/fuzzing_tc.sh
+++ b/recipes/linux/fuzzing_tc.sh
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# /force-deps=fuzzing-decision
 
 set -e
 set -x
@@ -22,4 +23,12 @@ apt-install-auto \
     python3-pip \
     python3-wheel
 
-retry pip3 install 'git+https://github.com/MozillaSecurity/orion#subdirectory=services/fuzzing-decision'
+# assert that SRCDIR is set
+[ -n "$SRCDIR" ]
+
+if [ "$EDIT" = "1" ]
+then
+    retry pip3 install -e "$SRCDIR"
+else
+    retry pip3 install "$SRCDIR"
+fi

--- a/recipes/linux/fuzzmanager.sh
+++ b/recipes/linux/fuzzmanager.sh
@@ -24,7 +24,12 @@ apt-install-auto \
     python3-setuptools \
     python3-wheel
 
-cd /home/worker
-
-git-clone https://github.com/MozillaSecurity/FuzzManager fuzzmanager
-retry pip3 install ./fuzzmanager boto
+retry pip3 install boto
+if [ "$EDIT" = "1" ]
+then
+    cd "${DESTDIR-/home/worker}"
+    git-clone https://github.com/MozillaSecurity/FuzzManager fuzzmanager
+    retry pip3 install -e ./fuzzmanager
+else
+    retry pip3 install "git+https://github.com/MozillaSecurity/FuzzManager"
+fi

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -14,9 +14,10 @@ RUN useradd -d /home/worker -s /bin/bash -m worker
 
 COPY recipes/linux/ /tmp/recipes/
 COPY services/funfuzz/setup.sh /tmp/recipes/
+COPY services/fuzzing-decision /tmp/fuzzing-tc
 COPY base/linux/etc/pip.conf /etc/pip.conf
 RUN /tmp/recipes/setup.sh \
-    && rm -rf /tmp/recipes
+    && rm -rf /tmp/recipes /tmp/fuzzing-tc
 
 COPY services/funfuzz/status.sh /home/worker/
 COPY services/funfuzz/launch.sh /home/worker/

--- a/services/funfuzz/setup.sh
+++ b/services/funfuzz/setup.sh
@@ -22,7 +22,7 @@ cd "${0%/*}"
 ./credstash.sh
 ./fluentbit.sh
 ./fuzzfetch.sh
-./fuzzing_tc.sh
+SRCDIR=/tmp/fuzzing-tc ./fuzzing_tc.sh
 ./fuzzmanager.sh
 ./grcov.sh
 ./gsutil.sh

--- a/services/grizzly/Dockerfile
+++ b/services/grizzly/Dockerfile
@@ -13,10 +13,11 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN useradd -d /home/worker -s /bin/bash -m worker
 
 COPY recipes/linux/ /tmp/recipes/
+COPY services/fuzzing-decision /src/fuzzing-tc
 COPY services/grizzly/setup.sh /tmp/recipes/
 COPY base/linux/etc/pip.conf /etc/pip.conf
 RUN /tmp/recipes/setup.sh \
-    && rm -rf /tmp/recipes /tmp/setup.sh
+    && rm -rf /tmp/recipes
 COPY services/grizzly/rwait.py /usr/local/bin/rwait
 COPY services/grizzly/launch-grizzly.sh services/grizzly/launch-grizzly-worker.sh /home/worker/
 

--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -22,7 +22,7 @@ cd "${0%/*}"
 ./credstash.sh
 ./fluentbit.sh
 ./fuzzfetch.sh
-./fuzzing_tc.sh
+EDIT=1 SRCDIR=/src/fuzzing-tc ./fuzzing_tc.sh
 ./fuzzmanager.sh
 ./grcov.sh
 ./htop.sh

--- a/services/langfuzz/Dockerfile
+++ b/services/langfuzz/Dockerfile
@@ -13,9 +13,10 @@ ENV TASKCLUSTER_FUZZING_POOL unknown
 
 RUN useradd -d /home/ubuntu -s /bin/bash -m ubuntu
 
+COPY services/fuzzing-decision /tmp/fuzzing-tc
 COPY services/langfuzz/setup.sh /tmp/
 RUN /tmp/setup.sh \
-    && rm -rf /tmp/setup.sh
+    && rm -rf /tmp/setup.sh /tmp/fuzzing-tc
 COPY services/langfuzz/launch-langfuzz.sh /home/ubuntu/
 COPY services/langfuzz/fluentbit.conf /etc/td-agent-bit/td-agent-bit.conf
 COPY services/langfuzz/sysctl.conf /etc/sysctl.d/60-langfuzz.conf

--- a/services/langfuzz/service.yaml
+++ b/services/langfuzz/service.yaml
@@ -1,1 +1,3 @@
 name: langfuzz
+force_deps:
+  - fuzzing-decision

--- a/services/langfuzz/setup.sh
+++ b/services/langfuzz/setup.sh
@@ -84,7 +84,7 @@ retry apt-get install -y -qq --no-install-recommends "${packages[@]}"
 # Install fuzzing-tc
 # this is used as the entrypoint to intercept stderr/stdout and save it to /logs/live.log
 # when run under Taskcluster
-retry python3 -m pip install 'git+https://github.com/MozillaSecurity/orion#subdirectory=services/fuzzing-decision'
+retry python3 -m pip install /tmp/fuzzing-tc
 
 # Install taskcluster CLI
 TC_VERSION="$(curl --retry 5 -s "https://github.com/taskcluster/taskcluster/releases/latest" | sed 's/.\+\/tag\/\(.\+\)".\+/\1/')"

--- a/services/libfuzzer/Dockerfile
+++ b/services/libfuzzer/Dockerfile
@@ -14,9 +14,10 @@ RUN useradd -d /home/worker -s /bin/bash -m worker
 
 COPY recipes/linux/ /tmp/recipes/
 COPY services/libfuzzer/setup.sh /tmp/recipes/
+COPY services/fuzzing-decision /tmp/fuzzing-tc
 COPY base/linux/etc/pip.conf /etc/pip.conf
 RUN /tmp/recipes/setup.sh \
-    && rm -rf /tmp/recipes
+    && rm -rf /tmp/recipes /tmp/fuzzing-tc
 
 COPY services/libfuzzer/launch.sh /home/worker/
 COPY services/libfuzzer/libfuzzer.sh /home/worker/

--- a/services/libfuzzer/setup.sh
+++ b/services/libfuzzer/setup.sh
@@ -26,7 +26,7 @@ EDIT=1 ./fuzzmanager.sh
 ./grcov.sh
 ./gsutil.sh
 ./fluentbit.sh
-./fuzzing_tc.sh
+SRCDIR=/tmp/fuzzing-tc ./fuzzing_tc.sh
 ./taskcluster.sh
 
 packages=(

--- a/services/libfuzzer/setup.sh
+++ b/services/libfuzzer/setup.sh
@@ -22,7 +22,7 @@ cd "${0%/*}"
 ./fuzzfetch.sh
 ./credstash.sh
 ./berglas.sh
-./fuzzmanager.sh
+EDIT=1 ./fuzzmanager.sh
 ./grcov.sh
 ./gsutil.sh
 ./fluentbit.sh


### PR DESCRIPTION
And also:
- don't keep a clone of FuzzManager unless needed, just install it
- disable progress-bar for all pip install