### PR TITLE
[grizzly] Use Taskcluster secrets instead of credstash

### DIFF
--- a/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/monitor.py
+++ b/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/monitor.py
@@ -217,6 +217,10 @@ class ReductionMonitor(ReductionWorkflow):
                 "docker-worker:capability:device:hostSharedMemory",
                 "docker-worker:capability:device:loopbackAudio",
                 "secrets:get:project/fuzzing/credstash-aws-auth",
+                "secrets:get:project/fuzzing/deploy-bearspray",
+                "secrets:get:project/fuzzing/deploy-grizzly-private",
+                "secrets:get:project/fuzzing/fuzzmanagerconf",
+                "secrets:get:project/fuzzing/google-logging-creds",
             ],
             "tags": {},
         }

--- a/services/grizzly/launch-grizzly-worker.sh
+++ b/services/grizzly/launch-grizzly-worker.sh
@@ -19,7 +19,7 @@ eval "$(ssh-agent -s)"
 mkdir -p .ssh
 
 # Get fuzzmanager configuration from credstash
-retry credstash get fuzzmanagerconf > .fuzzmanagerconf
+get-tc-secret fuzzmanagerconf .fuzzmanagerconf
 
 # Update fuzzmanager config for this instance
 mkdir -p signatures
@@ -31,12 +31,11 @@ setup-fuzzmanager-hostname "$SHIP"
 chmod 0600 .fuzzmanagerconf
 
 # only clone if it wasn't already mounted via docker run -v
-if [ ! -d ~/bearspray ]; then
+if [ ! -d /src/bearspray ]; then
   update-ec2-status "Setup: cloning bearspray"
 
   # Get deployment key from credstash
-  retry credstash get deploy-bearspray.pem > .ssh/id_ecdsa.bearspray
-  chmod 0600 .ssh/id_ecdsa.bearspray
+  get-tc-secret deploy-bearspray .ssh/id_ecdsa.bearspray
 
   cat <<- EOF >> .ssh/config
 
@@ -47,8 +46,8 @@ if [ ! -d ~/bearspray ]; then
 	EOF
 
   # Checkout bearspray
-  git init bearspray
-  ( cd bearspray
+  git init /src/bearspray
+  ( cd /src/bearspray
     git remote add -t master origin git@bearspray:MozillaSecurity/bearspray.git
     retry git fetch -v --depth 1 --no-tags origin master
     git reset --hard FETCH_HEAD
@@ -56,7 +55,7 @@ if [ ! -d ~/bearspray ]; then
 fi
 
 update-ec2-status "Setup: installing bearspray"
-retry python3 -m pip install --user -U -e ./bearspray
+retry python3 -m pip install --user -U -e /src/bearspray
 
 update-ec2-status "Setup: launching bearspray"
 

--- a/services/grizzly/launch-grizzly.sh
+++ b/services/grizzly/launch-grizzly.sh
@@ -13,9 +13,8 @@ source /home/worker/.local/bin/common.sh
 SHIP="$(get-provider)"
 su worker -c ". ~/.local/bin/common.sh && setup-aws-credentials '$SHIP'"
 
-mkdir -p /etc/google/auth /etc/td-agent-bit
-su worker -c '. ~/.local/bin/common.sh && retry credstash get google-logging-creds.json' > /etc/google/auth/application_default_credentials.json
-chmod 0600 /etc/google/auth/application_default_credentials.json
+get-tc-secret google-logging-creds /etc/google/auth/application_default_credentials.json raw
+mkdir -p /etc/td-agent-bit
 cat > /etc/td-agent-bit/td-agent-bit.conf << EOF
 [SERVICE]
     Daemon       On


### PR DESCRIPTION
This revision will still make credstash available. Once bearspray is switched over, credstash can be removed.