### PR TITLE
Miscellaneous changes in fuzzing-decision and orion-builder

### DIFF
--- a/services/bugmon/Dockerfile
+++ b/services/bugmon/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jason Kratzer <jkratzer@mozilla.com>
 
 ENV LOGNAME         worker
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 COPY recipes/linux /tmp/recipes
 COPY services/bugmon/setup.sh /tmp/recipes

--- a/services/ci-node-10/Dockerfile
+++ b/services/ci-node-10/Dockerfile
@@ -6,7 +6,7 @@ FROM node:10-slim
 
 LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="${i+1}"; done; "$@"; } \
     && retry apt-get update -qq \

--- a/services/ci-node-12/Dockerfile
+++ b/services/ci-node-12/Dockerfile
@@ -6,7 +6,7 @@ FROM node:12-slim
 
 LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="${i+1}"; done; "$@"; } \
     && retry apt-get update -qq \

--- a/services/funfuzz/Dockerfile
+++ b/services/funfuzz/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
 ENV LOGNAME         worker
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN useradd -d /home/worker -s /bin/bash -m worker
 

--- a/services/fuzzing-decision/Dockerfile
+++ b/services/fuzzing-decision/Dockerfile
@@ -1,17 +1,26 @@
-FROM python:3.8-slim
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-ENV DEBIAN_FRONTEND=noninteractive
+FROM alpine:latest
 
-# Setup git for ssh clones
-# Setup gcc to build patiencediff
-RUN apt-get update -qq && apt-get install --no-install-recommends -qq gcc libc6-dev git openssh-client && rm -rf /var/lib/apt/lists/*
-RUN mkdir ~/.ssh && chmod 0700 ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts
+LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
-COPY services/fuzzing-decision /src
-
-RUN pip install --disable-pip-version-check --no-cache-dir --progress-bar off --quiet -e "/src[decision]"
+COPY services/fuzzing-decision /src/fuzzing-decision
+RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1))"; done; "$@"; } \
+    && retry apk add --no-cache build-base git openssh-client python3 py3-pip py3-requests py3-wheel python3-dev \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && retry pip install --no-cache-dir --disable-pip-version-check --progress-bar off -e "/src/fuzzing-decision[decision]" \
+    && find /usr/lib/python*/site-packages -name "*.so" -exec strip "{}" + \
+    && apk del build-base py3-pip py3-wheel python3-dev \
+    && python -m compileall -b -q /usr/lib \
+    && find /usr/lib -name \*.py -delete \
+    && find /usr/lib -name __pycache__ -exec rm -rf "{}" + \
+    && mkdir -p ~/.ssh \
+    && chmod 0700 ~/.ssh \
+    && ssh-keyscan github.com > ~/.ssh/known_hosts
 
 # Setup env variable for tc-admin.py discovery
-ENV TC_ADMIN_PY=/src/tc-admin.py
+ENV TC_ADMIN_PY=/src/fuzzing-decision/tc-admin.py
 
 CMD ["fuzzing-decision"]

--- a/services/fuzzing-decision/src/fuzzing_decision/decision/cli.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/cli.py
@@ -12,7 +12,7 @@ from .workflow import Workflow
 
 
 def main():
-    parser = build_cli_parser(prog="fuzzing-pool-launch")
+    parser = build_cli_parser(prog="fuzzing-decision")
     parser.add_argument(
         "pool_name", type=str, help="The target fuzzing pool to create tasks for"
     )

--- a/services/fuzzmanager/Dockerfile
+++ b/services/fuzzmanager/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Gary Kwong <gkwong@mozilla.com>
 
 RUN useradd -d /home/fuzzmanager -s /bin/bash -m fuzzmanager
 WORKDIR /home/fuzzmanager
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
   echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" >> /etc/apt/sources.list \

--- a/services/gr-css-reports/Dockerfile
+++ b/services/gr-css-reports/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jason Kratzer <jkratzer@mozilla.com>
 
 ENV LOGNAME         worker
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 COPY recipes/linux /tmp/recipes
 COPY services/gr-css-reports/setup.sh /tmp/recipes

--- a/services/grizzly/Dockerfile
+++ b/services/grizzly/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
 ENV LOGNAME         worker
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN useradd -d /home/worker -s /bin/bash -m worker
 

--- a/services/langfuzz/Dockerfile
+++ b/services/langfuzz/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Christian Holler <choller@mozilla.com>
 
 ENV LOGNAME         ubuntu
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 ENV TASKCLUSTER_FUZZING_POOL unknown
 
 RUN useradd -d /home/ubuntu -s /bin/bash -m ubuntu

--- a/services/libfuzzer/Dockerfile
+++ b/services/libfuzzer/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
 ENV LOGNAME         worker
 ENV HOSTNAME        taskcluster-worker
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN useradd -d /home/worker -s /bin/bash -m worker
 

--- a/services/orion-builder/Dockerfile
+++ b/services/orion-builder/Dockerfile
@@ -46,7 +46,7 @@ RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1
     && retry git fetch -q origin "$FUSE_OVERLAYFS_VER:$FUSE_OVERLAYFS_VER" \
     && git -c advice.detachedHead=false checkout "$FUSE_OVERLAYFS_VER" \
     && ./autogen.sh \
-    && ./configure --prefix /usr || cat config.log \
+    && ./configure --prefix /usr \
     && make clean \
     && make \
     && make install \
@@ -68,12 +68,12 @@ RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1
     && ln -s /usr/bin/python3 /usr/bin/python \
     && retry pip --no-cache-dir --disable-pip-version-check install https://github.com/mozilla/task-boot/archive/0.3.2.tar.gz \
     && retry pip --no-cache-dir --disable-pip-version-check install -e /src/orion-builder \
-    && find /usr/lib/python*/site-packages -name "*.so" -exec strip {} \; \
+    && find /usr/lib/python*/site-packages -name "*.so" -exec strip "{}" + \
     && rm -rf /root/.cache /usr/bin/__pycache__ \
     # precompile .py files
     && python -m compileall -b -q /usr/lib \
     && find /usr/lib -name \*.py -delete \
-    && find /usr/lib -name __pycache__ -exec rm -rf \{\} + \
+    && find /usr/lib -name __pycache__ -exec rm -rf "{}" + \
     # install docker registry
     && retry wget -q -O /bin/registry https://github.com/docker/distribution-library-image/raw/$REGISTRY_VER/amd64/registry \
     && retry wget -q -O /root/registry.yml https://github.com/docker/distribution-library-image/raw/$REGISTRY_VER/amd64/config-example.yml \

--- a/services/orion-builder/Dockerfile
+++ b/services/orion-builder/Dockerfile
@@ -43,7 +43,7 @@ RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1
     && git init /fuse-overlayfs \
     && cd /fuse-overlayfs \
     && git remote add origin https://github.com/containers/fuse-overlayfs \
-    && retry git fetch -q origin "$FUSE_OVERLAYFS_VER:$FUSE_OVERLAYFS_VER" \
+    && retry git fetch -q --depth 1 --no-tags origin "$FUSE_OVERLAYFS_VER:$FUSE_OVERLAYFS_VER" \
     && git -c advice.detachedHead=false checkout "$FUSE_OVERLAYFS_VER" \
     && ./autogen.sh \
     && ./configure --prefix /usr \
@@ -56,7 +56,7 @@ RUN retry () { i=0; while [ $i -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1
     && git init /img \
     && cd /img \
     && git remote add origin https://github.com/genuinetools/img \
-    && retry git fetch -q origin "$IMG_VER" \
+    && retry git fetch -q --depth 1 --no-tags origin "$IMG_VER" \
     && git -c advice.detachedHead=false checkout "$IMG_VER" \
     && retry go get -u github.com/jteeuwen/go-bindata/... \
     && retry make BUILDTAGS="seccomp noembed" \

--- a/services/orion-builder/src/orion_builder/build.py
+++ b/services/orion-builder/src/orion_builder/build.py
@@ -39,6 +39,12 @@ class BuildArgs(CommonArgs):
             help="Path to the Dockerfile (default: Dockerfile)",
         )
         self.parser.add_argument(
+            "--build-arg",
+            action="append",
+            default=[],
+            help="Docker build args",
+        )
+        self.parser.add_argument(
             "--image",
             default=getenv("IMAGE_NAME"),
             help="Docker image name (without repository, default: IMAGE_NAME)",


### PR DESCRIPTION
- switch DEBIAN_FRONTEND to an ARG (build-time only) instead of ENV (build and run-time)
- switch fuzzing-decision to use alpine (80% smaller image)
- fix bug in orion-builder Dockerfile, if configure failed it would have been masked
- add support in orion-builder for `docker build --build-arg`  (already supported by task-boot, passed through)