### PR TITLE
[orion-decison] Add recipe tests.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,10 +50,9 @@ repos:
       - id: hadolint
         name: Lint dockerfiles
         language: system
-        files: Dockerfile
+        files: "Dockerfile(-[A-Za-z_.-]+)?"
         require_serial: true
         entry: ./scripts/pre-commit-hadolint.sh
-        exclude: "^.*/windows/.*$"
       - id: fuzzing-decision-lint
         name: Run linters for fuzzing_decision
         entry: bash -c 'cd services/fuzzing-decision && exec tox -e lint'

--- a/services/orion-decision/src/orion_decision/task_templates/recipe_test.yaml
+++ b/services/orion-decision/src/orion_decision/task_templates/recipe_test.yaml
@@ -1,0 +1,31 @@
+taskGroupId: "${task_group}"
+dependencies: []
+created: "${now}"
+deadline: "${deadline}"
+provisionerId: "${provisioner}"
+schedulerId: "${scheduler}"
+workerType: "${worker}"
+payload:
+  command:
+    - build
+    - --build-arg
+    - "recipe=${recipe_name}"
+  env:
+    ARCHIVE_PATH: /image.tar
+    BUILD_TOOL: img
+    DOCKERFILE: "${dockerfile}"
+    GIT_REPOSITORY: "${clone_url}"
+    GIT_REVISION: "${commit}"
+    IMAGE_NAME: "mozillasecurity/test-${recipe_name}"
+  capabilities:
+    privileged: true
+  image: "mozillasecurity/orion-builder:latest"
+  maxRunTime: !!int "${max_run_time}"
+scopes:
+  - "docker-worker:capability:privileged"
+  - "queue:scheduler-id:${scheduler}"
+metadata:
+  description: "Test for recipe ${recipe_name}"
+  name: "Orion recipe ${recipe_name} test"
+  owner: "${owner_email}"
+  source: "${source_url}"

--- a/services/orion-decision/tests/fixtures/services03/test1/Dockerfile
+++ b/services/orion-decision/tests/fixtures/services03/test1/Dockerfile
@@ -1,1 +1,2 @@
 RUN recipes/linux/install.sh
+RUN common/script.sh

--- a/services/orion-decision/tests/fixtures/services07/test1/Dockerfile
+++ b/services/orion-decision/tests/fixtures/services07/test1/Dockerfile
@@ -1,0 +1,1 @@
+FROM mozillasecurity/test2:latest

--- a/services/orion-decision/tests/fixtures/services07/test1/service.yaml
+++ b/services/orion-decision/tests/fixtures/services07/test1/service.yaml
@@ -1,0 +1,1 @@
+name: test1

--- a/services/orion-decision/tests/fixtures/services07/test2/Dockerfile
+++ b/services/orion-decision/tests/fixtures/services07/test2/Dockerfile
@@ -1,0 +1,1 @@
+FROM mozillasecurity/test1:latest

--- a/services/orion-decision/tests/fixtures/services07/test2/service.yaml
+++ b/services/orion-decision/tests/fixtures/services07/test2/service.yaml
@@ -1,0 +1,1 @@
+name: test2

--- a/services/test-recipes/Dockerfile
+++ b/services/test-recipes/Dockerfile
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:20.04
+
+LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
+
+ARG recipe
+
+COPY recipes/linux /recipes
+COPY services/test-recipes/launch.sh /
+
+RUN chmod +x /launch.sh && exec /launch.sh

--- a/services/test-recipes/Dockerfile-fuzzing_tc
+++ b/services/test-recipes/Dockerfile-fuzzing_tc
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:20.04
+
+LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
+
+ARG recipe
+
+COPY recipes/linux /recipes
+COPY services/test-recipes/launch.sh /
+
+COPY services/fuzzing-decision /src/fuzzing-tc
+ARG SRCDIR=/src/fuzzing-tc
+
+RUN chmod +x /launch.sh && exec /launch.sh

--- a/services/test-recipes/launch.sh
+++ b/services/test-recipes/launch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+set -o pipefail
+
+cd /recipes
+
+# shellcheck source=recipes/linux/common.sh
+source ./common.sh
+sys-update
+
+# if "supports-test" tag is found, run pre-test setup (if any)
+{
+  # shellcheck disable=SC2154
+  ! grep -q supports-test "./${recipe}"
+} || {
+  echo "Running ${recipe} test pre-setup..." >&2
+  "./${recipe}" test-setup
+}
+
+"./${recipe}"
+./cleanup.sh
+
+# either the "supports-test" tag isn't found, or the tests pass
+{
+  ! grep -q supports-test "./${recipe}"
+} || {
+  echo "Running ${recipe} tests..." >&2
+  "./${recipe}" test
+}


### PR DESCRIPTION
This includes recipes directly in the dependency graph, instead of indirectly as path-deps of services.