### PR TITLE
Fix CI matrix

### DIFF
--- a/services/ci-py-38-win/setup.sh
+++ b/services/ci-py-38-win/setup.sh
@@ -21,6 +21,10 @@ sed -i "s/^\\(    \\)maker = PipScriptMaker(.*/&\r\n\\1maker.executable = '\\/us
   msys64/mingw64/lib/python*/site-packages/pip/_internal/operations/install/wheel.py
 
 pip install tox
+# patch tox to workaround https://github.com/tox-dev/tox/issues/1982
+sed -i "s/^        is_bin = ($/& True or/" \
+  msys64/mingw64/lib/python*/site-packages/tox/config/__init__.py
+
 pip install poetry
 rm -rf msys64/mingw64/share/man/ msys64/mingw64/share/doc/ msys64/usr/share/doc/ msys64/usr/share/man/
 cp -r orion/services/orion-decision orion-decision

--- a/services/orion-decision/src/orion_decision/ci_scheduler.py
+++ b/services/orion-decision/src/orion_decision/ci_scheduler.py
@@ -152,6 +152,8 @@ class CIScheduler:
                     task["payload"]["features"]["taskclusterProxy"] = True
                     for sec in chain(job.secrets, self.matrix.secrets):
                         task["scopes"].append(f"secrets:get:{sec.secret}")
+                    # ensure scopes are unique
+                    task["scopes"] = list(set(task["scopes"]))
                 if not job.require_previous_stage_pass:
                     task["requires"] = "all-resolved"
                 task["dependencies"].extend(prev_stage)

--- a/services/orion-decision/tests/test_cischeduler.py
+++ b/services/orion-decision/tests/test_cischeduler.py
@@ -162,6 +162,9 @@ def test_ci_create_02(mocker, platform, matrix_secret, job_secret):
     if matrix_secret is not None or job_secret is not None:
         expected["payload"].setdefault("features", {})
         expected["payload"]["features"]["taskclusterProxy"] = True
+    assert set(task["scopes"]) == set(expected["scopes"])
+    assert len(task["scopes"]) == len(expected["scopes"])
+    task["scopes"] = expected["scopes"]
     assert task == expected
     assert all(sec.secret in task["payload"]["env"]["CI_JOB"] for sec in job.secrets)
 


### PR DESCRIPTION
- pass CI scopes only once
- patch tox to workaround https://github.com/tox-dev/tox/issues/1982