### PR TITLE
[jstests] Migrate legacy test bundling code to distiller job

### DIFF
--- a/services/js-tests-distiller/launch.sh
+++ b/services/js-tests-distiller/launch.sh
@@ -56,3 +56,23 @@ $DISTILLER --delete-timeouts --test $OUTPUT --binary debug64/dist/bin/js
 # Create zip bundle
 mkdir -p output
 zip output/jstests-distilled.zip -r tests
+
+# Cleanup
+rm -Rf tests
+
+## Legacy test bundle creation ##
+
+TEST262_LIST=/home/ubuntu/LangFuzz/tools/tests/test262.list
+
+# This is a hack to extract include directives for jit-tests and convert them to jstests shell.js style
+(cd $JITTESTS && for f in `grep -rnl " include:" . | grep directives` ; do cp lib/`egrep -o 'include:[a-zA-Z0-9\.\-]+' $f | head -n1 | sed -e 's/include://'` `echo $f | sed -e 's/directives.txt//'`shell.js ; done)
+
+cp -R $JITTESTS $JSTESTS .
+
+# Make a limited copy of test262 as it is too large to distribute it all
+cd tests
+rsync -rv --files-from $TEST262_LIST test262 test262-limited
+rm -Rf test262
+cd ..
+
+zip output/jstests-legacy.zip -r jit-test tests

--- a/services/js-tests-distiller/setup.sh
+++ b/services/js-tests-distiller/setup.sh
@@ -49,6 +49,7 @@ packages=(
   python3-pip
   python3-setuptools
   python3-wheel
+  rsync
   screen
   software-properties-common
   unzip


### PR DESCRIPTION
This creates another archive that is used by the non-distiller jobs. We can evaluate later if we still need this, but for now I'd like to simply migrate it to get be able to proceed with decommissioning the old build jobs.

I will also create a PR to add the resulting zip as an artifact.