### PR TITLE
Fix xpcshell merge command line.

### DIFF
--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -249,10 +249,15 @@ then
   export LD_LIBRARY_PATH=~/js/dist/bin
 fi
 
-TARGET_ARGS=""
+TARGET_ARGS=()
 if [[ -n "$XPCRT" ]]
 then
-  TARGET_ARGS="-xpcshell"
+  # The official truber maneuver™
+  #
+  # Firefox strips the -xpcshell arg, but if libfuzzer forks a subprocess
+  # (which it does during merge) then the -xpcshell flag is missing. Repeating
+  # the argument generates a warning at launch, but -merge will work.
+  TARGET_ARGS+=(-xpcshell -xpcshell)
 fi
 
 # shellcheck disable=SC2206
@@ -280,7 +285,7 @@ then
     --libfuzzer-instances "$LIBFUZZER_INSTANCES" \
     --stats "./stats" \
     --tool "${TOOLNAME:-libFuzzer-$FUZZER}" \
-    --cmd "$HOME/$TARGET_BIN" "$TARGET_ARGS" "${LIBFUZZER_ARGS[@]}"
+    --cmd "$HOME/$TARGET_BIN" "${TARGET_ARGS[@]}" "${LIBFUZZER_ARGS[@]}"
 else
   update-ec2-status "Starting afl-libfuzzer-daemon with --s3-corpus-refresh" || true
   run-afl-libfuzzer-daemon "${S3_PROJECT_ARGS[@]}" \


### PR DESCRIPTION
Fix this problem when running `firefox -xpcshell -merge=1`
```
FUZZER=client.js firefox -xpcshell -merge=1 tests queues
INFO: Seed: 2171328303
INFO: Loaded 1 modules   (1264857 inline 8-bit counters): 1264857 [0x7fa5708798b0, 0x7fa5709ae589), 
INFO: Loaded 1 PC tables (1264857 PCs): 1264857 [0x7fa5709ae590,0x7fa571cfb320), 
MERGE-OUTER: 5553 files, 85 in the initial corpus, 0 processed earlier
MERGE-OUTER: attempt 1
*** You are running in headless mode.
Running Fuzzer tests...
Fuzzing Interface: Error: No testing callback found
```