### PR TITLE
When cycling pools, only look for tasks launched by hooks in the past 2 days.

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/__init__.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/__init__.py
@@ -12,3 +12,4 @@ WORKER_POOL_PREFIX = "proj-fuzzing"
 HOOK_PREFIX = "project-fuzzing"
 PROVIDER_IDS = {"aws": "community-tc-workers-aws", "gcp": "community-tc-workers-google"}
 DECISION_TASK_SECRET = "project/fuzzing/decision"
+CANCEL_TASK_DAYS = 2


### PR DESCRIPTION
Pushing to the fuzzing config repo has timed out because there are so many hook fires to search under for tasks. Only search recent hook fires. Limit to 2 days, since our max cycle-time is 1.