### PR TITLE
Install llvm-symbolizer as it isn't always packaged.

### DIFF
--- a/recipes/linux/llvm-symbolizer.sh
+++ b/recipes/linux/llvm-symbolizer.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# supports-test
+
+set -e
+set -x
+set -o pipefail
+
+# shellcheck source=recipes/linux/common.sh
+source "${0%/*}/common.sh"
+
+#### Install LLVM
+
+VERSION=12
+
+case "${1-install}" in
+  install)
+    apt-install-auto \
+      binutils \
+      ca-certificates \
+      curl \
+      zstd
+
+    curl -L "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-clang-${VERSION}.latest/artifacts/public%2Fbuild%2Fclang.tar.zst" | zstdcat | tar -x -C /usr/local/bin --strip-components=2 clang/bin/llvm-symbolizer
+    strip --strip-unneeded /usr/local/bin/llvm-symbolizer
+    ;;
+  test)
+    llvm-symbolizer --version
+    ;;
+esac

--- a/recipes/linux/llvm.sh
+++ b/recipes/linux/llvm.sh
@@ -58,5 +58,6 @@ case "${1-install}" in
     ;;
   test)
     clang --version
+    llvm-symbolizer --version
     ;;
 esac

--- a/services/funfuzz/setup.sh
+++ b/services/funfuzz/setup.sh
@@ -23,6 +23,7 @@ SRCDIR=/tmp/fuzzing-tc ./fuzzing_tc.sh
 ./gsutil.sh
 ./htop.sh
 ./taskcluster.sh
+./llvm-symbolizer.sh
 
 packages=(
   apt-utils

--- a/services/fuzzilli/setup.sh
+++ b/services/fuzzilli/setup.sh
@@ -28,6 +28,7 @@ EDIT=1 SRCDIR=/src/fuzzing-tc ./fuzzing_tc.sh
 ./taskcluster.sh
 ./fuzzmanager.sh
 ./grcov.sh
+./llvm-symbolizer.sh
 
 #### Bootstrap Packages
 


### PR DESCRIPTION
Extract llvm-symbolizer from the gecko clang toolchain artifact.