### PR TITLE
[grizzly-android] Change Android boot timeouts

### DIFF
--- a/services/grizzly-android/setup.cfg
+++ b/services/grizzly-android/setup.cfg
@@ -19,3 +19,7 @@ python_requires = >=3.6
 [options.entry_points]
 console_scripts =
     emulator-install = emulator_install:main
+
+[options.package_data]
+emulator_install =
+    py.typed


### PR DESCRIPTION
* Make Android boot timeout a parameter (default 120s in automation, 60s (unchanged) for command line
* Make retry delay a parameter for the @retry decorator, so it can be decreased where needed