### PR TITLE
[grizzly] Add mesa-vulkan-driver debug symbols

### DIFF
--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -97,6 +97,7 @@ dbgsym_packages=(
   libwayland-egl1
   mesa-va-drivers
   mesa-vdpau-drivers
+  mesa-vulkan-drivers
 )
 
 sys-embed "${packages_with_recommends[@]}"


### PR DESCRIPTION
Adds debug symbols for mesa-vulkan-driver related crash stacks.