### PR TITLE
Try to bypass permission problems when calling rmtree

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/common/util.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/common/util.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import stat
+from pathlib import Path
+from typing import Any, Callable, Union
+
+PathArg = Union[str, Path]
+
+
+def onerror(func: Callable[[PathArg], None], path: PathArg, _exc_info: Any) -> None:
+    """Error handler for `shutil.rmtree`.
+
+    If the error is due to an access error (read only file)
+    it attempts to add write permission and then retries.
+
+    If the error is for another reason it re-raises the error.
+
+    Copyright Michael Foord 2004
+    Released subject to the BSD License
+    ref: http://www.voidspace.org.uk/python/recipebook.shtml#utils
+
+    Usage : `shutil.rmtree(path, onerror=onerror)`
+    """
+    if not os.access(path, os.W_OK):
+        # Is the error an access error?
+        os.chmod(path, stat.S_IWUSR)
+        func(path)
+    else:
+        # this should only ever be called from an exception context
+        raise  # pylint: disable=misplaced-bare-raise

--- a/services/fuzzing-decision/src/fuzzing_decision/decision/workflow.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/workflow.py
@@ -16,6 +16,7 @@ from tcadmin.appconfig import AppConfig
 
 from ..common import taskcluster
 from ..common.pool import MachineTypes
+from ..common.util import onerror
 from ..common.workflow import Workflow as CommonWorkflow
 from . import HOOK_PREFIX, WORKER_POOL_PREFIX
 from .pool import PoolConfigLoader, cancel_tasks
@@ -187,4 +188,4 @@ class Workflow(CommonWorkflow):
             folder_ = str(folder)
             if folder_.startswith(tempfile.gettempdir()):
                 LOG.info(f"Removing tempdir clone {folder_}")
-                shutil.rmtree(folder_)
+                shutil.rmtree(folder_, onerror=onerror)

--- a/services/fuzzing-decision/src/fuzzing_decision/pool_launch/cli.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/pool_launch/cli.py
@@ -2,7 +2,6 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
-
 import argparse
 import logging
 import os
@@ -10,6 +9,7 @@ import shutil
 from typing import List, Optional
 
 from ..common.cli import build_cli_parser
+from ..common.util import onerror
 from .launcher import PoolLauncher
 
 
@@ -55,7 +55,7 @@ def main(args: Optional[List[str]] = None) -> None:
         launcher.load_params()
         if "path" not in config["fuzzing_config"]:
             # we cloned fuzzing-tc-config, clean it up
-            shutil.rmtree(launcher.fuzzing_config_dir)
+            shutil.rmtree(launcher.fuzzing_config_dir, onerror=onerror)
 
     if not parsed_args.dry_run:
         # Execute command


### PR DESCRIPTION
This is to try to workaround this:

```
INFO:fuzzing_decision.common.workflow:Cloning git@github.com:MozillaSecurity/fuzzing-tc-config.git
Warning: Permanently added the ECDSA host key for IP address '140.82.114.3' to the list of known hosts.
INFO:fuzzing_decision.common.workflow:Using cloned config files in C:\Users\TASK_1~1\AppData\Local\Temp\tmp4x2pqv49fuzzing-tc-config.git
INFO:fuzzing_decision.common.workflow:Updating repo to refs/heads/master
Traceback (most recent call last):
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\task_165581316691787\msys64\opt\python\Scripts\fuzzing-pool-launch.exe\__main__.py", line 7, in <module>
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\site-packages\fuzzing_decision\pool_launch\cli.py", line 58, in main
    shutil.rmtree(launcher.fuzzing_config_dir)
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 740, in rmtree
    return _rmtree_unsafe(path, onerror)
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 613, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 613, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 613, in _rmtree_unsafe
    _rmtree_unsafe(fullname, onerror)
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 618, in _rmtree_unsafe
    onerror(os.unlink, fullname, sys.exc_info())
  File "C:\Users\task_165581316691787\msys64\opt\python\lib\shutil.py", line 616, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: 'C:\\Users\\TASK_1~1\\AppData\\Local\\Temp\\tmp4x2pqv49fuzzing-tc-config.git\\.git\\objects\\pack\\pack-759bfea3ac33a160c452eb11f250af95d74d40ba.idx'
```