### PR TITLE
Update homebrew version

### DIFF
--- a/services/ci-py-310-osx/service.yaml
+++ b/services/ci-py-310-osx/service.yaml
@@ -1,5 +1,5 @@
 name: ci-py-310-osx
 type: homebrew
-base: https://github.com/Homebrew/brew/archive/refs/tags/3.3.11.tar.gz
+base: https://github.com/Homebrew/brew/archive/refs/tags/3.5.4.tar.gz
 force_dirty:
   - orion-decision

--- a/services/ci-py-38-osx/service.yaml
+++ b/services/ci-py-38-osx/service.yaml
@@ -1,5 +1,5 @@
 name: ci-py-38-osx
 type: homebrew
-base: https://github.com/Homebrew/brew/archive/refs/tags/3.3.11.tar.gz
+base: https://github.com/Homebrew/brew/archive/refs/tags/3.5.4.tar.gz
 force_dirty:
   - orion-decision

--- a/services/ci-py-39-osx/service.yaml
+++ b/services/ci-py-39-osx/service.yaml
@@ -1,5 +1,5 @@
 name: ci-py-39-osx
 type: homebrew
-base: https://github.com/Homebrew/brew/archive/refs/tags/3.3.11.tar.gz
+base: https://github.com/Homebrew/brew/archive/refs/tags/3.5.4.tar.gz
 force_dirty:
   - orion-decision

--- a/services/grizzly-macos/service.yaml
+++ b/services/grizzly-macos/service.yaml
@@ -1,5 +1,5 @@
 name: grizzly-macos
 type: homebrew
-base: https://github.com/Homebrew/brew/archive/refs/tags/3.3.11.tar.gz
+base: https://github.com/Homebrew/brew/archive/refs/tags/3.5.4.tar.gz
 force_dirty:
   - fuzzing-decision


### PR DESCRIPTION
Seeing this failure when making a non-macos specific change in fuzzing-decision:

```
Error: Invalid formula: /Users/runner/work/orion/orion/tasks/task_165789188963172/homebrew/Library/Taps/homebrew/homebrew-core/Formula/libgccjit.rb
libgccjit: undefined method `on_arm' for #<Class:0x00007fa0e6b331f0>
Error: Cannot tap homebrew/core: invalid syntax in tap!
Error: Failure while executing; `/Users/runner/work/orion/orion/tasks/task_165789188963172/homebrew/bin/brew tap homebrew/core` exited with 1.
```

I'm guessing this is just an outdated homebrew problem.