### PR TITLE
Report ossfuzz coverage of nss targets to CovManager

### DIFF
--- a/services/nss-coverage/Dockerfile
+++ b/services/nss-coverage/Dockerfile
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:20.04
+
+LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
+
+ENV LOGNAME         worker
+ENV HOSTNAME        taskcluster-worker
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN useradd -d /home/worker -s /bin/bash -m worker
+
+COPY recipes/linux/ /src/recipes/
+COPY services/fuzzing-decision /src/fuzzing-tc
+COPY services/nss-coverage/setup.sh /src/recipes/setup-nss-coverage.sh
+RUN /src/recipes/setup-nss-coverage.sh
+COPY \
+    services/nss-coverage/merge-coverage.py \
+    services/nss-coverage/nspr_map.json \
+    services/nss-coverage/launch.sh \
+    /home/worker/
+
+ENV LANG   en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+USER worker
+WORKDIR /home/worker
+ENTRYPOINT ["/usr/local/bin/fuzzing-pool-launch"]
+CMD ["/home/worker/launch.sh"]

--- a/services/nss-coverage/launch.sh
+++ b/services/nss-coverage/launch.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+cd
+set -e
+set -x
+set -o pipefail
+
+# shellcheck source=recipes/linux/common.sh
+source .local/bin/common.sh
+
+if [[ ! -e .fuzzmanagerconf ]]; then
+  # Get fuzzmanager configuration from TC
+  set +x
+  get-tc-secret fuzzmanagerconf .fuzzmanagerconf
+  set -x
+
+  # Update fuzzmanager config for this instance
+  mkdir -p signatures
+  cat >> .fuzzmanagerconf <<- EOF
+	sigdir = $HOME/signatures
+	tool = nss-coverage
+	EOF
+  setup-fuzzmanager-hostname
+  chmod 0600 .fuzzmanagerconf
+fi
+
+REVISION="$(curl --retry 5 --compressed -sSL https://community-tc.services.mozilla.com/api/index/v1/task/project.fuzzing.coverage-revision.latest/artifacts/public/coverage-revision.txt)"
+export REVISION
+NSS_TAG="$(curl --retry 5 -sSL "https://hg.mozilla.org/mozilla-central/raw-file/$REVISION/security/nss/TAG-INFO")"
+NSPR_TAG="$(curl --retry 5 -sSL "https://hg.mozilla.org/mozilla-central/raw-file/$REVISION/nsprpub/TAG-INFO")"
+
+if [[ ! -d clang ]]; then
+  # resolve current clang toolchain
+  curl --retry 5 -sSLO "https://hg.mozilla.org/mozilla-central/raw-file/$REVISION/taskcluster/ci/toolchain/clang.yml"
+  python3 <<- "EOF" > clang.txt
+	import yaml
+	with open("clang.yml") as fd:
+	  data = yaml.load(fd, Loader=yaml.CLoader)
+	for tc, defn in data.items():
+	  if defn.get("run", {}).get("toolchain-alias", {}).get("by-project", {}).get("default") == "linux64-clang":
+	    print(tc)
+	    break
+	else:
+	  raise Exception("No linux64-clang toolchain found")
+	EOF
+  CLANG_INDEX="$(cat clang.txt)"
+  rm clang.txt clang.yml
+
+  # install clang
+  curl --retry 5 -L "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.$CLANG_INDEX.latest/artifacts/public/build/clang.tar.zst" | zstdcat | tar -x
+  curl --retry 5 -L "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.${CLANG_INDEX/clang/x64-compiler-rt}.latest/artifacts/public/build/compiler-rt-x86_64-unknown-linux-gnu.tar.zst" | zstdcat | tar --strip-components=1 -C clang/lib/clang/* -x
+fi
+CC="$PWD/clang/bin/clang"
+CXX="$PWD/clang/bin/clang++"
+export CC
+export CXX
+$CC --version
+
+CFLAGS="-O2 -g --coverage"
+CXXFLAGS="$CFLAGS"
+LDFLAGS="$CFLAGS"
+export CFLAGS
+export CXXFLAGS
+export LDFLAGS
+
+# clone nss/nspr
+retry hg clone -r "$NSPR_TAG" https://hg.mozilla.org/projects/nspr
+retry hg clone -r "$NSS_TAG" https://hg.mozilla.org/projects/nss
+
+# download corpus
+mkdir -p corpus
+cd corpus
+tls_targets=()
+non_tls_targets=()
+for p in ../nss/fuzz/options/*; do
+  fuzzer="$(basename "$p" .options)"
+  if [[ "$fuzzer" = "${fuzzer%-no_fuzzer_mode}" ]]; then
+    tls_targets+=("$fuzzer")
+  else
+    non_tls_targets+=("${fuzzer%-no_fuzzer_mode}")
+  fi
+  if [[ ! -d "$fuzzer" ]]; then
+    curl --retry 5 -LO "https://storage.googleapis.com/nss-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/nss_$fuzzer/public.zip"
+    mkdir "$fuzzer"
+    cd "$fuzzer"
+    7z x ../public.zip
+    cd ..
+    rm public.zip
+  fi
+done
+cd ..
+
+COVRUNTIME=${COVRUNTIME-300}
+
+function run-target {
+  target="$1"
+  corpus="$2"
+  shift 2
+
+  find . -name "*.gcda" -delete
+  timeout -s 2 -k $((COVRUNTIME + 60)) $((COVRUNTIME + 30)) "./dist/Debug/bin/nssfuzz-$target" "corpus/$corpus" -max_total_time="$COVRUNTIME" || :
+
+  # Collect coverage count data.
+  RUST_BACKTRACE=1 grcov nss \
+    -t coveralls+ \
+    --token NONE \
+    --commit-sha "$REVISION" \
+    --guess-directory-when-missing \
+    -s nss/out/Debug/ \
+    -p "$PWD" \
+    > coverage-nss.json
+  RUST_BACKTRACE=1 grcov nspr \
+    -t coveralls+ \
+    --token NONE \
+    --commit-sha "$REVISION" \
+    --guess-directory-when-missing \
+    -s nspr/Debug/dist/include/nspr/ \
+    -p "$PWD" \
+    --path-mapping nspr_map.json \
+    > coverage-nspr.json
+  python merge-coverage.py coverage-nss.json coverage-nspr.json > "coverage-$corpus.json"
+  rm coverage-nss.json coverage-nspr.json
+
+  # Submit coverage data.
+  python3 -m CovReporter \
+    --repository mozilla-central \
+    --description "libFuzzer (nss-$corpus,rt=$COVRUNTIME)" \
+    --tool "nss-$corpus" \
+    --submit "coverage-$corpus.json"
+}
+
+# build tls-mode targets
+rm -rf dist nss/out nspr/Debug
+cd nss
+./build.sh -c -v --fuzz --fuzz=tls --disable-tests
+cd ..
+
+# run each tls-mode target
+for target in "${tls_targets[@]}"; do
+  run-target "$target" "$target"
+done
+
+# build non-tls-mode targets
+rm -rf dist nss/out nspr/Debug
+cd nss
+./build.sh -c -v --fuzz --disable-tests
+cd ..
+
+# run each non-tls-mode target
+for target in "${non_tls_targets[@]}"; do
+  run-target "$target" "$target-no_fuzzer_mode"
+done

--- a/services/nss-coverage/merge-coverage.py
+++ b/services/nss-coverage/merge-coverage.py
@@ -1,0 +1,38 @@
+import json
+import sys
+
+data = None
+
+def translate_fn(fn):
+    if fn.startswith("nss/"):
+        return f"security/nss/{fn[4:]}"
+    if fn.startswith("pr/") or fn.startswith("lib/") or fn.startswith("config/"):
+        return f"nsprpub/{fn}"
+    return fn
+
+for inp in sys.argv[1:]:
+    with open(inp) as fd:
+        if data is None:
+            data = json.load(fd)
+            data["source_files"] = {
+                translate_fn(obj["name"]): obj
+                for obj in data["source_files"]
+            }
+            for fn, obj in data["source_files"].items():
+                obj["name"] = fn
+        else:
+            new = json.load(fd)
+            for obj in new["source_files"]:
+                fn = translate_fn(obj["name"])
+                if fn in data["source_files"]:
+                    old = data["source_files"][fn]
+                    for idx, (oldn, newn) in enumerate(zip(old["coverage"], obj["coverage"])):
+                        if oldn or newn:
+                            oldn += newn
+                            old["coverage"][idx] = newn
+                else:
+                    data["source_files"][fn] = obj
+                    obj["name"] = fn
+
+data["source_files"] = list(data["source_files"].values())
+json.dump(data, sys.stdout)

--- a/services/nss-coverage/nspr_map.json
+++ b/services/nss-coverage/nspr_map.json
@@ -1,0 +1,14 @@
+{
+"../../../../../pr/src/md/unix/unix_errors.c": "nspr/pr/src/md/unix/unix_errors.c",
+"../../../../../pr/src/md/unix/linux.c": "nspr/pr/src/md/unix/linux.c",
+"../../../../../pr/src/md/unix/unix.c": "nspr/pr/src/md/unix/unix.c",
+"../../../../../pr/src/md/unix/uxrng.c": "nspr/pr/src/md/unix/uxrng.c",
+"../../../../../pr/src/md/unix/uxshm.c": "nspr/pr/src/md/unix/uxshm.c",
+"../../../../../pr/src/md/unix/uxproces.c": "nspr/pr/src/md/unix/uxproces.c",
+"../../../pr/src/prvrsion.c": "nspr/pr/src/prvrsion.c",
+"../../../lib/ds/plhash.c": "nspr/lib/ds/plhash.c",
+"../../../lib/ds/plarena.c": "nspr/lib/ds/plarena.c",
+"../../config/nsinstall.c": "nspr/config/nsinstall.c",
+"../../config/now.c": "nspr/config/now.c",
+"../../../lib/ds/plvrsion.c": "nspr/lib/ds/plvrsion.c"
+}

--- a/services/nss-coverage/service.yaml
+++ b/services/nss-coverage/service.yaml
@@ -1,0 +1,1 @@
+name: nss-coverage

--- a/services/nss-coverage/setup.sh
+++ b/services/nss-coverage/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+set -e
+set -x
+set -o pipefail
+
+# shellcheck source=recipes/linux/common.sh
+source "${0%/*}/common.sh"
+
+#### Bootstrap Packages
+
+sys-update
+
+#### Install recipes
+
+cd "${0%/*}"
+./fluentbit.sh
+./fuzzfetch.sh
+EDIT=1 SRCDIR=/src/fuzzing-tc ./fuzzing_tc.sh
+./fuzzmanager.sh
+./grcov.sh
+./taskcluster.sh
+
+packages=(
+  binutils curl gyp jshon libgcc-9-dev libssl-dev libstdc++-9-dev libxml2 locales make mercurial ninja-build python-is-python3 python3 python3-yaml zlib1g-dev zstd
+)
+
+sys-embed "${packages[@]}"
+
+#### Base System Configuration
+
+# Generate locales
+locale-gen en_US.utf8
+
+#### Base Environment Configuration
+
+cat << 'EOF' >> /home/worker/.bashrc
+
+# FuzzOS
+export PS1='🐳  \[\033[1;36m\]\h \[\033[1;34m\]\W\[\033[0;35m\] \[\033[1;36m\]λ\[\033[0m\] '
+EOF
+
+mkdir -p /home/worker/.local/bin
+
+# Add `cleanup.sh` to let images perform standard cleanup operations.
+cp "${0%/*}/cleanup.sh" /home/worker/.local/bin/cleanup.sh
+
+# Add shared `common.sh` to Bash
+cp "${0%/*}/common.sh" /home/worker/.local/bin/common.sh
+printf "source ~/.local/bin/common.sh\n" >> /home/worker/.bashrc
+
+/home/worker/.local/bin/cleanup.sh
+
+mkdir -p /home/worker/.ssh /root/.ssh
+chmod 0700 /home/worker/.ssh /root/.ssh
+cat << EOF | tee -a /root/.ssh/config /home/worker/.ssh/config > /dev/null
+Host *
+UseRoaming no
+EOF
+retry ssh-keyscan github.com | tee -a /root/.ssh/known_hosts /home/worker/.ssh/known_hosts > /dev/null
+
+chown -R worker:worker /home/worker
+chmod 0777 /src


### PR DESCRIPTION
At the moment this does not use the daemon to report any crashes to FM, and it uses the public snapshot of ossfuzz corpus.