### PR TITLE
NSS coverage image fixes

### DIFF
--- a/services/nss-coverage/launch-worker.sh
+++ b/services/nss-coverage/launch-worker.sh
@@ -91,7 +91,7 @@ for p in ../nss/fuzz/options/*; do
     curl --retry 5 -LO "https://storage.googleapis.com/nss-backup.clusterfuzz-external.appspot.com/corpus/libFuzzer/nss_$fuzzer/public.zip"
     mkdir "$fuzzer"
     cd "$fuzzer"
-    7z x ../public.zip
+    unzip ../public.zip
     cd ..
     rm public.zip
   fi

--- a/services/nss-coverage/setup.sh
+++ b/services/nss-coverage/setup.sh
@@ -18,14 +18,31 @@ sys-update
 
 cd "${0%/*}"
 ./fluentbit.sh
-./fuzzfetch.sh
 EDIT=1 SRCDIR=/src/fuzzing-tc ./fuzzing_tc.sh
 ./fuzzmanager.sh
 ./grcov.sh
 ./taskcluster.sh
 
 packages=(
-  binutils curl gyp jshon libgcc-9-dev libssl-dev libstdc++-9-dev libxml2 locales make mercurial ninja-build python-is-python3 python3 python3-yaml zlib1g-dev zstd
+  binutils
+  curl
+  gyp
+  jshon
+  libgcc-9-dev
+  libssl-dev
+  libstdc++-9-dev
+  libxml2
+  locales
+  make
+  mercurial
+  ninja-build
+  psmisc
+  python-is-python3
+  python3
+  python3-yaml
+  unzip
+  zlib1g-dev
+  zstd
 )
 
 sys-embed "${packages[@]}"


### PR DESCRIPTION
* remove unused fuzzfetch recipe
* use unzip instead of 7z (7z was installed by fuzzfetch recipe)
* add basic task status reporting
* add `NO_REPORT=1` to allow running `launch-worker.sh` without reporting to CovManager for local testing
* add psmisc for killall (caused [coverage task](https://community-tc.services.mozilla.com/tasks/Lswm1TI2QZ-0uS3KfY39oA/runs/0/logs/project/fuzzing/private/logs/live.log) to fail after success)