### PR TITLE
Use hook role for decision task scopes.

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
@@ -329,7 +329,6 @@ class PoolConfiguration(CommonPoolConfiguration):
         decision_task["scopes"] = sorted(
             chain(decision_task["scopes"], self.get_scopes())
         )
-        add_capabilities_for_scopes(decision_task)
         if env is not None:
             assert set(decision_task["payload"]["env"]).isdisjoint(set(env))
             decision_task["payload"]["env"].update(env)
@@ -347,6 +346,10 @@ class PoolConfiguration(CommonPoolConfiguration):
 
         self_cycle_crons = self.cycle_crons()
         assert self_cycle_crons is not None
+
+        scopes = decision_task["scopes"] + ["queue:create-task:highest:proj-fuzzing/ci"]
+        decision_task["scopes"] = [f"assume:hook-id:{HOOK_PREFIX}/{self.task_id}"]
+
         yield Hook(
             bindings=(),
             description=DESCRIPTION,
@@ -363,8 +366,7 @@ class PoolConfiguration(CommonPoolConfiguration):
         yield Role(
             description=DESCRIPTION,
             roleId=f"hook-id:{HOOK_PREFIX}/{self.task_id}",
-            scopes=decision_task["scopes"]
-            + ["queue:create-task:highest:proj-fuzzing/ci"],
+            scopes=scopes,
         )
 
     def artifact_map(self, expires: str) -> Dict[str, Dict[str, str]]:
@@ -505,7 +507,6 @@ class PoolConfigMap(CommonPoolConfigMap):
             )
         )
         decision_task["scopes"] = sorted(chain(decision_task["scopes"], all_scopes))
-        add_capabilities_for_scopes(decision_task)
         if env is not None:
             assert set(decision_task["payload"]["env"]).isdisjoint(set(env))
             decision_task["payload"]["env"].update(env)
@@ -523,6 +524,10 @@ class PoolConfigMap(CommonPoolConfigMap):
 
         self_cycle_crons = self.cycle_crons()
         assert self_cycle_crons is not None
+
+        scopes = decision_task["scopes"] + ["queue:create-task:highest:proj-fuzzing/ci"]
+        decision_task["scopes"] = [f"assume:hook-id:{HOOK_PREFIX}/{self.task_id}"]
+
         yield Hook(
             bindings=(),
             description=DESCRIPTION,
@@ -539,8 +544,7 @@ class PoolConfigMap(CommonPoolConfigMap):
         yield Role(
             roleId=f"hook-id:{HOOK_PREFIX}/{self.task_id}",
             description=DESCRIPTION,
-            scopes=decision_task["scopes"]
-            + ["queue:create-task:highest:proj-fuzzing/ci"],
+            scopes=scopes,
         )
 
     def build_tasks(self, parent_task_id: str, env: Optional[Dict[str, str]] = None):

--- a/services/fuzzing-decision/tests/test_pool.py
+++ b/services/fuzzing-decision/tests/test_pool.py
@@ -129,12 +129,7 @@ def _get_expected_hook(platform: Union[List[str], str] = "linux") -> Dict[str, A
             "retries": 5,
             "routes": empty_str_list,
             "schedulerId": "-",
-            "scopes": [
-                "queue:cancel-task:-/*",
-                f"queue:create-task:highest:proj-fuzzing/{platform}-test",
-                "queue:scheduler-id:-",
-                "secrets:get:project/fuzzing/decision",
-            ],
+            "scopes": [f"assume:hook-id:project-fuzzing/{platform}-test"],
             "tags": empty_str_dict,
             "workerType": "ci",
         },


### PR DESCRIPTION
This is to work-around https://github.com/taskcluster/taskcluster/issues/5660. When the scope list reaches a certain size, it can bloat the header size until it causes API calls to fail when the decision task runs.

Fixes #222 