### PR TITLE
Fix Homebrew shebang rewriting

### DIFF
--- a/scripts/relocate_homebrew.sh
+++ b/scripts/relocate_homebrew.sh
@@ -14,8 +14,8 @@ relative_to () {
 }
 
 # Rewrite she-bang scripts that reference an interpreter in HOMEBREW_PREFIX to use /usr/bin/env
-# shellcheck disable=SC2046
-find $(find . -name bin -type d) -type f -exec file -h \{\} \+ | grep "$HOMEBREW_PREFIX" | cut -d: -f1 | while read -r inp
+# shellcheck disable=SC2039,SC2046
+find $(find . -name bin -type d) -type f -exec awk "FNR>1 {nextfile} /${HOMEBREW_PREFIX//\//\\/}/ { print FILENAME ; nextfile }" \{\} \+ | while read -r inp
 do
   sed -E -i '' '1s,^#!(/[^/]+)*/([^/]+)$,#!/usr/bin/env \2,' "$inp"
 done

--- a/services/ci-py-310-osx/setup.sh
+++ b/services/ci-py-310-osx/setup.sh
@@ -20,6 +20,7 @@ format = columns
 upgrade-strategy = only-if-needed
 progress-bar = off
 EOF
+export PIP_CONFIG_FILE="$PWD/pip/pip.ini"
 
 # install utils to match linux ci images
 python -m pip install tox

--- a/services/ci-py-38-osx/setup.sh
+++ b/services/ci-py-38-osx/setup.sh
@@ -20,6 +20,7 @@ format = columns
 upgrade-strategy = only-if-needed
 progress-bar = off
 EOF
+export PIP_CONFIG_FILE="$PWD/pip/pip.ini"
 
 # install utils to match linux ci images
 python -m pip install tox

--- a/services/ci-py-39-osx/setup.sh
+++ b/services/ci-py-39-osx/setup.sh
@@ -20,6 +20,7 @@ format = columns
 upgrade-strategy = only-if-needed
 progress-bar = off
 EOF
+export PIP_CONFIG_FILE="$PWD/pip/pip.ini"
 
 # install utils to match linux ci images
 python -m pip install tox


### PR DESCRIPTION
For some reason this changed since moving from Catalina to Big Sur. We need to rewrite the shebang line of scripts to make it relocatable.