### PR TITLE
Fix bug in cron

### DIFF
--- a/services/orion-decision/src/orion_decision/cron.py
+++ b/services/orion-decision/src/orion_decision/cron.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from logging import getLogger
 from typing import Optional
 
+from dateutil.parser import isoparse
 from taskcluster.exceptions import TaskclusterRestFailure
 
 from . import CRON_PERIOD, Taskcluster
@@ -107,7 +108,7 @@ class CronScheduler(Scheduler):
                 )
                 rebuild = True
             else:
-                if result["expires"] < next_run:
+                if isoparse(result["expires"]) < next_run:
                     LOG.warning(
                         "%s %s is dirty because %s expires %s",
                         type(svc).__name__,

--- a/services/orion-decision/tests/test_cron.py
+++ b/services/orion-decision/tests/test_cron.py
@@ -75,7 +75,7 @@ def test_cron_mark_rebuild(
             if f".{svc}." in path:
                 LOG.debug("%s is expired", path)
                 return {
-                    "expires": now,
+                    "expires": now.isoformat(),
                 }
         for svc in missing_svcs:
             if f".{svc}." in path:
@@ -83,7 +83,7 @@ def test_cron_mark_rebuild(
                 raise TaskclusterRestFailure("404", None)
         LOG.debug("%s is not expired", path)
         return {
-            "expires": now + CRON_PERIOD * 2,
+            "expires": (now + CRON_PERIOD * 2).isoformat(),
         }
 
     index.findTask.side_effect = _find_task


### PR DESCRIPTION
Timestamps come from TC as `str`. The test covering this made the same mistake.

[task UfKAypHpREGIdW030EwVyw](https://community-tc.services.mozilla.com/tasks/UfKAypHpREGIdW030EwVyw) is an example (Most recent fire from [orion-cron hook](https://community-tc.services.mozilla.com/hooks/project-fuzzing/orion-cron)).