### PR TITLE
[rr] Build rr from source until a new release is made.

### DIFF
--- a/recipes/linux/rr.sh
+++ b/recipes/linux/rr.sh
@@ -13,6 +13,8 @@ source "${0%/*}/common.sh"
 
 #### Install rr
 
+REVISION=026cef968a34ae2b3e272e7ac7b6c9c9f98261a0
+
 if is-arm64; then
   echo "[INFO] rr is currently not supported on any ARM architecture."
   exit
@@ -20,17 +22,55 @@ fi
 
 case "${1-install}" in
   install)
+    "${0%/*}/llvm.sh" auto
     apt-install-auto \
-      ca-certificates \
-      curl
+      capnproto \
+      cmake \
+      dpkg-dev \
+      file \
+      g++-multilib \
+      gdb \
+      git \
+      libcapnp-dev \
+      ninja-build \
+      pkg-config \
+      python3-pexpect \
+      zlib1g-dev
 
-    TMPD="$(mktemp -d -p. rr.dl.XXXXXXXXXX)"
+    export CC=clang
+    export CXX=clang++
+
+    TMPD="$(mktemp -d -p. rr.build.XXXXXXXXXX)"
     pushd "$TMPD" >/dev/null
-      PLATFORM="Linux-x86_64"
-      LATEST_VERSION=$(get-latest-github-release "rr-debugger/rr")
-      FN="rr-$LATEST_VERSION-$PLATFORM.deb"
-      curl --retry 5 -sLO "https://github.com/rr-debugger/rr/releases/download/$LATEST_VERSION/$FN"
-      sys-embed "./$FN"
+      git init rr
+      pushd rr >/dev/null
+        git remote add -t master origin https://github.com/rr-debugger/rr.git
+        retry git fetch --no-tags origin "$REVISION"
+        git reset --hard "$REVISION"
+        PATCH="git.$(git log -1 --date=iso | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' | tr -d '-').$(git rev-parse --short HEAD)"
+        sed -i "s/set(rr_VERSION_PATCH [0-9]\\+)/set(rr_VERSION_PATCH $PATCH)/" CMakeLists.txt
+        git apply <<- "EOF"
+	diff --git a/CMakeLists.txt b/CMakeLists.txt
+	index d0d02346..29ac3b57 100644
+	--- a/CMakeLists.txt
+	+++ b/CMakeLists.txt
+	@@ -1984,6 +1984,7 @@ set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README.md")
+	 set(CPACK_PACKAGE_VENDOR "rr-debugger")
+
+	 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "rr-debugger")
+	+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+	 set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+	 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+	   set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+	EOF
+      popd >/dev/null
+      mkdir obj
+      pushd obj >/dev/null
+        CC=clang CXX=clang++ cmake -G Ninja -Dstrip=TRUE ../rr
+        cmake --build .
+        cpack -G DEB
+        dpkg -i dist/rr-*.deb
+      popd >/dev/null
     popd >/dev/null
     rm -rf "$TMPD"
     ;;


### PR DESCRIPTION
@pyoor reports that until https://github.com/rr-debugger/rr/pull/3362 is in an rr release, we will have problems with pernosco traces collected on Skylake CPUs. Build rr from current master until then.