### PR TITLE
[bugmon] Pin poetry to version 1.2.2

### DIFF
--- a/services/bugmon/launch-bugmon.sh
+++ b/services/bugmon/launch-bugmon.sh
@@ -26,7 +26,7 @@ export PATH=$PATH:/home/worker/.local/bin
 export ARTIFACT_DEST="/bugmon-artifacts"
 export TC_ARTIFACT_ROOT="project/fuzzing/bugmon"
 
-curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3 - --version 1.2.2
 git-clone https://github.com/MozillaSecurity/bugmon-tc.git ./bugmon-tc
 cd bugmon-tc
 poetry install


### PR DESCRIPTION
Pin poetry to version 1.2.2 until https://github.com/python-poetry/poetry/issues/7184 is fixed.