### PR TITLE
[fuzzing-decision] Don't overwrite existing environment

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/pool_launch/launcher.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/pool_launch/launcher.py
@@ -62,7 +62,12 @@ class PoolLauncher(Workflow):
         if pool_config.command:
             assert not self.command, "Specify command-line args XOR pool.command"
             self.command = pool_config.command.copy()
-        self.environment.update(pool_config.macros)
+        for key, value in pool_config.macros.items():
+            # don't override existing macros
+            if key in self.environment:
+                LOG.info("Skip setting existing macro %r", key)
+                continue
+            self.environment[key] = value
         self.environment["FUZZING_POOL_NAME"] = pool_config.name
 
     def exec(self) -> None:

--- a/services/fuzzing-decision/tests/test_launch.py
+++ b/services/fuzzing-decision/tests/test_launch.py
@@ -59,12 +59,13 @@ def test_load_params(tmp_path: Path) -> None:
         "cpu": "arm64",
         "platform": "linux",
         "preprocess": "",
-        "macros": {"ENVVAR1": "123456", "ENVVAR2": "789abc"},
+        "macros": {"ENVVAR1": "123456", "ENVVAR2": "789abc", "ENVVAR3": "failed!"},
         "run_as_admin": False,
     }
 
     # test 1: environment from pool is merged
     launcher = PoolLauncher(["command", "arg"], "test-pool")
+    launcher.environment["ENVVAR3"] = "NO_MOD"
     launcher.fuzzing_config_dir = tmp_path
     with (tmp_path / "test-pool.yml").open("w") as test_cfg:
         yaml.dump(pool_data, stream=test_cfg)
@@ -74,6 +75,7 @@ def test_load_params(tmp_path: Path) -> None:
     assert launcher.environment == {
         "ENVVAR1": "123456",
         "ENVVAR2": "789abc",
+        "ENVVAR3": "NO_MOD",
         "FUZZING_POOL_NAME": "Amazing fuzzing pool",
         "STATIC": "value",
     }

--- a/services/grizzly-win/setup.sh
+++ b/services/grizzly-win/setup.sh
@@ -88,7 +88,7 @@ npm -v
 
 # get grcov
 curl --connect-timeout 25 --retry 5 -sSLO "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.win64-grcov.latest/artifacts/public/build/grcov.tar.zst"
-zstdcat grcov.tar.zst | tar xv
+zstdcat grcov.tar.zst | tar --strip-components=1 -xv
 mv grcov.exe msys64/usr/bin/
 ./msys64/usr/bin/grcov.exe --version
 


### PR DESCRIPTION
Only use values from pool config if they don't exist. This allows customization of one off TC tasks.