### PR TITLE
Force charset-normalizer version range

### DIFF
--- a/services/fuzzing-decision/setup.cfg
+++ b/services/fuzzing-decision/setup.cfg
@@ -10,6 +10,10 @@ platforms = any
 
 [options]
 install_requires =
+    # this should not be required, but until aiohttp cuts a release
+    # it seems to break as pip selects charset-normalizer 3.0.1
+    # despite knowing that aiohttp requires <3 ... ¯\_(ツ)_/¯
+    charset_normalizer<3
     taskcluster
     python-dateutil
     pyyaml


### PR DESCRIPTION
This can go away when aiohttp makes a release. (I think)

At install:
```
+ pip3 install --no-build-isolation -e /src/fuzzing-tc
ERROR: aiohttp 3.8.3 has requirement charset-normalizer<3.0,>=2.0, but you'll have charset-normalizer 3.0.1 which is incompatible.
+ cat /tmp/tmp.Sekeu50aDZ
Obtaining file:///src/fuzzing-tc
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting taskcluster
  Downloading taskcluster-47.0.3-py3-none-any.whl (141 kB)
Collecting python-dateutil
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting pyyaml
  Downloading PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (701 kB)
Collecting async-timeout>=2.0.0
  Downloading async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
Collecting mohawk>=0.3.4
  Downloading mohawk-1.1.0-py3-none-any.whl (22 kB)
Collecting slugid>=2
  Downloading slugid-2.0.0-py2.py3-none-any.whl (8.2 kB)
Collecting requests>=2.4.3
  Downloading requests-2.28.2-py3-none-any.whl (62 kB)
Collecting aiohttp>=3.7.4
  Downloading aiohttp-3.8.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.0 MB)
Collecting taskcluster-urls>=12.1.0
  Downloading taskcluster_urls-13.0.1-py3-none-any.whl (10 kB)
Collecting six>=1.5
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting certifi>=2017.4.17
  Downloading certifi-2022.12.7-py3-none-any.whl (155 kB)
Collecting idna<4,>=2.5
  Downloading idna-3.4-py3-none-any.whl (61 kB)
Collecting charset-normalizer<4,>=2
  Downloading charset_normalizer-3.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (195 kB)
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.14-py2.py3-none-any.whl (140 kB)
Collecting frozenlist>=1.1.1
  Downloading frozenlist-1.3.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (161 kB)
Collecting aiosignal>=1.1.2
  Downloading aiosignal-1.3.1-py3-none-any.whl (7.6 kB)
Collecting multidict<7.0,>=4.5
  Downloading multidict-6.0.4-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (121 kB)
Collecting yarl<2.0,>=1.0
  Downloading yarl-1.8.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (262 kB)
Collecting attrs>=17.3.0
  Downloading attrs-22.2.0-py3-none-any.whl (60 kB)
Installing collected packages: async-timeout, six, mohawk, slugid, certifi, idna, charset-normalizer, urllib3, requests, frozenlist, aiosignal, multidict, yarl, attrs, aiohttp, taskcluster-urls, python-dateutil, taskcluster, pyyaml, fuzzing-decision
  Running setup.py develop for fuzzing-decision
Successfully installed aiohttp-3.8.3 aiosignal-1.3.1 async-timeout-4.0.2 attrs-22.2.0 certifi-2022.12.7 charset-normalizer-3.0.1 frozenlist-1.3.3 fuzzing-decision idna-3.4 mohawk-1.1.0 multidict-6.0.4 python-dateutil-2.8.2 pyyaml-6.0 requests-2.28.2 six-1.16.0 slugid-2.0.0 taskcluster-47.0.3 taskcluster-urls-13.0.1 urllib3-1.26.14 yarl-1.8.2
```

and at run:
```
[taskcluster 2023-01-26 21:50:35.552Z] === Task Starting ===
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 792, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (charset-normalizer 3.0.1 (/usr/local/lib/python3.8/dist-packages), Requirement.parse('charset-normalizer<3.0,>=2.0'), {'aiohttp'})
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/bin/fuzzing-pool-launch", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3254, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3237, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 3266, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 586, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 599, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'charset-normalizer<3.0,>=2.0' distribution was not found and is required by aiohttp
[taskcluster 2023-01-26 21:50:45.332Z] === Task Finished ===
```