### PR TITLE
[ci-py] Add libssl-dev

### DIFF
--- a/services/ci-py-common/setup-linux.sh
+++ b/services/ci-py-common/setup-linux.sh
@@ -22,6 +22,7 @@ packages=(
   jshon
   libc6-dev
   libffi-dev
+  libssl-dev
   make
   openssh-client
   patch


### PR DESCRIPTION
This is needed to be able to build dependencies for grizzly that are lacking a wheel (aioquic on 3.11).