### PR TITLE
Fix orion cron

### DIFF
--- a/services/ci-node-14-win/service.yaml
+++ b/services/ci-node-14-win/service.yaml
@@ -1,3 +1,5 @@
 name: ci-node-14-win
 type: msys
 base: https://github.com/msys2/msys2-installer/releases/download/2022-10-28/msys2-base-x86_64-20221028.tar.xz
+force_dirty:
+  - orion-decision

--- a/services/ci-node-14/service.yaml
+++ b/services/ci-node-14/service.yaml
@@ -1,1 +1,3 @@
 name: ci-node-14
+force_dirty:
+  - orion-decision

--- a/services/ci-node-16-win/service.yaml
+++ b/services/ci-node-16-win/service.yaml
@@ -1,3 +1,5 @@
 name: ci-node-16-win
 type: msys
 base: https://github.com/msys2/msys2-installer/releases/download/2022-10-28/msys2-base-x86_64-20221028.tar.xz
+force_dirty:
+  - orion-decision

--- a/services/ci-node-16/service.yaml
+++ b/services/ci-node-16/service.yaml
@@ -1,1 +1,3 @@
 name: ci-node-16
+force_dirty:
+  - orion-decision

--- a/services/ci-node-18-win/service.yaml
+++ b/services/ci-node-18-win/service.yaml
@@ -1,3 +1,5 @@
 name: ci-node-18-win
 type: msys
 base: https://github.com/msys2/msys2-installer/releases/download/2022-10-28/msys2-base-x86_64-20221028.tar.xz
+force_dirty:
+  - orion-decision

--- a/services/ci-node-18/service.yaml
+++ b/services/ci-node-18/service.yaml
@@ -1,1 +1,3 @@
 name: ci-node-18
+force_dirty:
+  - orion-decision

--- a/services/orion-decision/src/orion_decision/cron.py
+++ b/services/orion-decision/src/orion_decision/cron.py
@@ -11,7 +11,7 @@ from typing import Optional
 from dateutil.parser import isoparse
 from taskcluster.exceptions import TaskclusterRestFailure
 
-from . import CRON_PERIOD, Taskcluster
+from . import ARTIFACTS_EXPIRE, CRON_PERIOD, Taskcluster
 from .git import GitRepo
 from .orion import Services
 from .scheduler import Scheduler
@@ -108,7 +108,13 @@ class CronScheduler(Scheduler):
                 )
                 rebuild = True
             else:
-                if isoparse(result["expires"]) < next_run:
+                if (
+                    min(
+                        isoparse(result["deadline"]) + ARTIFACTS_EXPIRE,
+                        isoparse(result["expires"]),
+                    )
+                    < next_run
+                ):
                     LOG.warning(
                         "%s %s is dirty because %s expires %s",
                         type(svc).__name__,

--- a/services/orion-decision/tests/test_cron.py
+++ b/services/orion-decision/tests/test_cron.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """Tests for Orion cron scheduler"""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from logging import getLogger
 from pathlib import Path
 from typing import Set
@@ -75,6 +75,7 @@ def test_cron_mark_rebuild(
             if f".{svc}." in path:
                 LOG.debug("%s is expired", path)
                 return {
+                    "deadline": (now - timedelta(days=7)).isoformat(),
                     "expires": now.isoformat(),
                 }
         for svc in missing_svcs:
@@ -83,6 +84,7 @@ def test_cron_mark_rebuild(
                 raise TaskclusterRestFailure("404", None)
         LOG.debug("%s is not expired", path)
         return {
+            "deadline": now.isoformat(),
             "expires": (now + CRON_PERIOD * 2).isoformat(),
         }
 


### PR DESCRIPTION
Artifacts expire before the task itself, so this was causing services that need rebuild to be missed (ci-node-16 artifact is expired but not rebuilt).