### PR TITLE
[orion-decision] Cron should look for deadline in task definition, not index.

### DIFF
--- a/services/orion-decision/src/orion_decision/cron.py
+++ b/services/orion-decision/src/orion_decision/cron.py
@@ -88,6 +88,7 @@ class CronScheduler(Scheduler):
         These will have their `dirty` attribute set, which is used to create tasks.
         """
         idx = Taskcluster.get_service("index")
+        queue = Taskcluster.get_service("queue")
         # for each service, check taskcluster index
         #   any service that would expire before next run, should be rebuilt
         assert self.now is not None
@@ -108,6 +109,7 @@ class CronScheduler(Scheduler):
                 )
                 rebuild = True
             else:
+                result = queue.task(result["taskId"])
                 if (
                     min(
                         isoparse(result["deadline"]) + ARTIFACTS_EXPIRE,


### PR DESCRIPTION
Use [queue.task()](https://community-tc.services.mozilla.com/docs/reference/platform/queue/api#task) instead of [index.findTask()](https://community-tc.services.mozilla.com/docs/reference/core/index/api#findTask) to lookup deadline.

this caused the following [failure](https://community-tc.services.mozilla.com/tasks/TlQTEz1HQs2VobCM_8SKGA):
```
Traceback (most recent call last):
  File "/usr/bin/cron-decision", line 8, in <module>
    sys.exit(cron_main())
             ^^^^^^^^^^^
  File "/src/orion-decision/src/orion_decision/cli.py", line 373, in cron_main
    sys.exit(CronScheduler.main(args))
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/src/orion-decision/src/orion_decision/cron.py", line 155, in main
    sched.mark_services_for_rebuild()
  File "/src/orion-decision/src/orion_decision/cron.py", line 113, in mark_services_for_rebuild
    isoparse(result["deadline"]) + ARTIFACTS_EXPIRE,
             ~~~~~~^^^^^^^^^^^^
KeyError: 'deadline'
[taskcluster 2023-06-23 16:03:32.526Z] === Task Finished ===
[taskcluster 2023-06-23 16:03:32.526Z] Unsuccessful task run with exit code: 1 completed in 8.119 seconds
```

... despite the fact that I had deadline defined in the test mocks 🙃