### PR TITLE
Fix retry function for non-bash shells.

### DIFF
--- a/services/ci-node-14-win/setup.sh
+++ b/services/ci-node-14-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/ci-node-16-win/setup.sh
+++ b/services/ci-node-16-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/ci-node-18-win/setup.sh
+++ b/services/ci-node-18-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/ci-py-310-win/setup.sh
+++ b/services/ci-py-310-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/ci-py-38-win/setup.sh
+++ b/services/ci-py-38-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/ci-py-39-win/setup.sh
+++ b/services/ci-py-39-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/coverage-revision/Dockerfile
+++ b/services/coverage-revision/Dockerfile
@@ -10,7 +10,7 @@ COPY base/linux/etc/pip.conf /etc/pip.conf
 
 WORKDIR /root
 
-RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="${i+1}"; done; "$@"; } \
+RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1))"; done; "$@"; } \
     && retry apk add --no-cache curl \
     && retry pip -q install fuzzfetch
 

--- a/services/credstash/Dockerfile
+++ b/services/credstash/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:latest
 
 LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
-RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="${i+1}"; done; "$@"; } \
+RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1))"; done; "$@"; } \
     && retry apk add --no-cache \
         py3-cryptography \
         py3-pip \

--- a/services/grizzly-reduce-monitor/Dockerfile
+++ b/services/grizzly-reduce-monitor/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 
 COPY services/grizzly-reduce-monitor /src
 
-RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="${i+1}"; done; "$@"; } \
+RUN retry () { i=0; while [ "$i" -lt 9 ]; do "$@" && return || sleep 30; i="$((i+1))"; done; "$@"; } \
     && retry apk add --no-cache \
         git \
         python3 \

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -8,7 +8,7 @@ retry () {
   do
     "$@" && return
     sleep 30
-    i="${i+1}"
+    i="$((i+1))"
   done
   "$@"
 }

--- a/services/grizzly-win/setup.sh
+++ b/services/grizzly-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages

--- a/services/site-scout-win/launch.sh
+++ b/services/site-scout-win/launch.sh
@@ -7,7 +7,7 @@ retry () {
   do
     "$@" && return
     sleep 30
-    i="${i+1}"
+    i="$((i+1))"
   done
   "$@"
 }

--- a/services/site-scout-win/setup.sh
+++ b/services/site-scout-win/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e -x
 
-retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
+retry () { i=0; while [ "$i" -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; }
 retry_curl () { curl -sSL --connect-timeout 25 --fail --retry 5 "$@"; }
 
 # base msys packages


### PR DESCRIPTION
Rather than `{0..9}`, this was generating the sequence: `[0, 1, 1, 1, ...]` which never terminated, resulting in an infinite retry.