### PR TITLE
[orion-scheduler] Don't use fixed scheduler id for created tasks.

### DIFF
--- a/services/orion-decision/src/orion_decision/__init__.py
+++ b/services/orion-decision/src/orion_decision/__init__.py
@@ -20,7 +20,6 @@ DEADLINE = timedelta(hours=2)
 MAX_RUN_TIME = timedelta(hours=1)
 OWNER_EMAIL = "truber@mozilla.com"
 PROVISIONER_ID = "proj-fuzzing"
-SCHEDULER_ID = "taskcluster-github"
 SOURCE_URL = "https://github.com/MozillaSecurity/orion"
 WORKER_TYPE = "ci"
 WORKER_TYPE_MSYS = "ci-windows"

--- a/services/orion-decision/src/orion_decision/cli.py
+++ b/services/orion-decision/src/orion_decision/cli.py
@@ -100,6 +100,11 @@ def _define_decision_args(parser: argparse.ArgumentParser) -> None:
         help="Create tasks in this task group (default: TASK_ID).",
     )
     parser.add_argument(
+        "--scheduler",
+        default=None,
+        help="Create tasks with this scheduler ID (default: fetch from TaskCluster).",
+    )
+    parser.add_argument(
         "--now",
         default=getenv("TASKCLUSTER_NOW", datetime.utcnow().isoformat()),
         type=isoparse,

--- a/services/orion-decision/tests/test_cischeduler.py
+++ b/services/orion-decision/tests/test_cischeduler.py
@@ -13,7 +13,7 @@ from pytest_mock import MockerFixture
 from taskcluster.utils import stringDate
 from yaml import safe_load as yaml_load
 
-from orion_decision import DEADLINE, MAX_RUN_TIME, PROVISIONER_ID, SCHEDULER_ID
+from orion_decision import DEADLINE, MAX_RUN_TIME, PROVISIONER_ID
 from orion_decision.ci_matrix import (
     CISecret,
     CISecretEnv,
@@ -59,7 +59,7 @@ def test_ci_create_01(mocker: MockerFixture) -> None:
         spec=GithubEvent(),
     )
     mocker.patch("orion_decision.ci_scheduler.CIMatrix", autospec=True)
-    sched = CIScheduler("test", evt, now, "group", {})
+    sched = CIScheduler("test", evt, now, "group", "scheduler", {})
     sched.create_tasks()
     assert queue.createTask.call_count == 0
 
@@ -139,7 +139,7 @@ def test_ci_create_02(
         sec = _create_secret(matrix_secret)
         secrets.append(sec)
     mtx.return_value.secrets = secrets
-    sched = CIScheduler("test", evt, now, "group", {})
+    sched = CIScheduler("test", evt, now, "group", "scheduler", {})
     sched.create_tasks()
     assert queue.createTask.call_count == 1
     _, task = queue.createTask.call_args[0]
@@ -158,7 +158,7 @@ def test_ci_create_02(
         "now": stringDate(now),
         "project": "test",
         "provisioner": PROVISIONER_ID,
-        "scheduler": SCHEDULER_ID,
+        "scheduler": "scheduler",
         "task_group": "group",
         "user": evt.user,
         "worker": WORKER_TYPES[platform],
@@ -220,7 +220,7 @@ def test_ci_create_03(mocker: MockerFixture, previous_pass: bool) -> None:
     )
     mtx.return_value.jobs = [job1, job2]
     mtx.return_value.secrets = []
-    sched = CIScheduler("test", evt, now, "group", {})
+    sched = CIScheduler("test", evt, now, "group", "scheduler", {})
     sched.create_tasks()
     assert queue.createTask.call_count == 2
     task1_id, task1 = queue.createTask.call_args_list[0][0]
@@ -236,7 +236,7 @@ def test_ci_create_03(mocker: MockerFixture, previous_pass: bool) -> None:
         "now": stringDate(now),
         "project": "test",
         "provisioner": PROVISIONER_ID,
-        "scheduler": SCHEDULER_ID,
+        "scheduler": "scheduler",
         "task_group": "group",
         "user": evt.user,
         "worker": WORKER_TYPES[job1.platform],

--- a/services/orion-decision/tests/test_cron.py
+++ b/services/orion-decision/tests/test_cron.py
@@ -21,7 +21,6 @@ from orion_decision import (
     MAX_RUN_TIME,
     OWNER_EMAIL,
     PROVISIONER_ID,
-    SCHEDULER_ID,
     SOURCE_URL,
     WORKER_TYPE,
 )
@@ -110,7 +109,15 @@ def test_cron_mark_rebuild(
     repo = mocker.Mock(spec=GitRepo.from_existing(root))
     repo.path = root
     repo.git = mocker.Mock(return_value="\n".join(str(p) for p in root.glob("**/*")))
-    sched = CronScheduler(repo, now, "group", "secret", "/path/to/repo", "push")
+    sched = CronScheduler(
+        repo,
+        now,
+        "group",
+        "scheduler",
+        "secret",
+        "/path/to/repo",
+        "push",
+    )
     sched.mark_services_for_rebuild()
     for svc in sched.services.values():
         assert svc.dirty == bool(svc.name in dirty_svcs)
@@ -125,7 +132,15 @@ def test_cron_create_01(mocker: MockerFixture) -> None:
     repo = mocker.Mock(spec=GitRepo.from_existing(root))
     repo.path = root
     repo.git = mocker.Mock(return_value="\n".join(str(p) for p in root.glob("**/*")))
-    sched = CronScheduler(repo, now, "group", "secret", "/path/to/repo", "push")
+    sched = CronScheduler(
+        repo,
+        now,
+        "group",
+        "scheduler",
+        "secret",
+        "/path/to/repo",
+        "push",
+    )
     sched.create_tasks()
     assert queue.createTask.call_count == 0
 
@@ -140,7 +155,15 @@ def test_cron_create_02(mocker: MockerFixture) -> None:
     repo.path = root
     repo.git = mocker.Mock(return_value="\n".join(str(p) for p in root.glob("**/*")))
     repo.head.return_value = "commit"
-    sched = CronScheduler(repo, now, "group", "secret", "https://example.com", "push")
+    sched = CronScheduler(
+        repo,
+        now,
+        "group",
+        "scheduler",
+        "secret",
+        "https://example.com",
+        "push",
+    )
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 2
@@ -157,7 +180,7 @@ def test_cron_create_02(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -175,7 +198,7 @@ def test_cron_create_02(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             skip_docker="0",
             source_url=SOURCE_URL,
@@ -198,7 +221,15 @@ def test_cron_create_03(mocker: MockerFixture) -> None:
     repo.path = root
     repo.git = mocker.Mock(return_value="\n".join(str(p) for p in root.glob("**/*")))
     repo.head.return_value = "commit"
-    sched = CronScheduler(repo, now, "group", "secret", "https://example.com", "push")
+    sched = CronScheduler(
+        repo,
+        now,
+        "group",
+        "scheduler",
+        "secret",
+        "https://example.com",
+        "push",
+    )
     sched.services["test1"].dirty = True
     sched.services["test2"].dirty = True
     sched.create_tasks()
@@ -216,7 +247,7 @@ def test_cron_create_03(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -234,7 +265,7 @@ def test_cron_create_03(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             skip_docker="0",
             source_url=SOURCE_URL,
@@ -258,7 +289,7 @@ def test_cron_create_03(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test2",
             source_url=SOURCE_URL,
             task_group="group",
@@ -280,7 +311,14 @@ def test_cron_create_04(mocker: MockerFixture) -> None:
     repo.git = mocker.Mock(return_value="\n".join(str(p) for p in root.glob("**/*")))
     repo.head.return_value = "commit"
     sched = CronScheduler(
-        repo, now, "group", "secret", "https://example.com", "push", dry_run=True
+        repo,
+        now,
+        "group",
+        "scheduler",
+        "secret",
+        "https://example.com",
+        "push",
+        dry_run=True,
     )
     sched.services["test1"].dirty = True
     sched.create_tasks()

--- a/services/orion-decision/tests/test_scheduler.py
+++ b/services/orion-decision/tests/test_scheduler.py
@@ -18,7 +18,6 @@ from orion_decision import (
     MAX_RUN_TIME,
     OWNER_EMAIL,
     PROVISIONER_ID,
-    SCHEDULER_ID,
     SOURCE_URL,
     WORKER_TYPE,
     WORKER_TYPE_BREW,
@@ -62,7 +61,7 @@ def test_mark_rebuild_01(mocker: MockerFixture) -> None:
         return_value="\n".join(str(p) for p in root.glob("**/*"))
     )
     evt.commit_message = "/force-rebuild"
-    sched = Scheduler(evt, None, "group", "secret", "branch")
+    sched = Scheduler(evt, None, "group", "scheduler", "secret", "branch")
     sched.mark_services_for_rebuild()
     for svc in sched.services.values():
         assert svc.dirty
@@ -79,7 +78,7 @@ def test_mark_rebuild_02(mocker: MockerFixture) -> None:
     )
     evt.commit_message = ""
     evt.list_changed_paths.return_value = [root / "recipes" / "linux" / "install.sh"]
-    sched = Scheduler(evt, None, "group", "secret", "branch")
+    sched = Scheduler(evt, None, "group", "scheduler", "secret", "branch")
     sched.mark_services_for_rebuild()
     assert evt.list_changed_paths.call_count == 1
     assert sched.services["test1"].dirty
@@ -101,7 +100,7 @@ def test_mark_rebuild_03(mocker: MockerFixture) -> None:
     )
     evt.commit_message = "/force-rebuild=test3,test6"
     evt.list_changed_paths.return_value = [root / "recipes" / "linux" / "install.sh"]
-    sched = Scheduler(evt, None, "group", "secret", "branch")
+    sched = Scheduler(evt, None, "group", "scheduler", "secret", "branch")
     sched.mark_services_for_rebuild()
     assert evt.list_changed_paths.call_count == 1
     assert sched.services["test1"].dirty
@@ -124,7 +123,7 @@ def test_create_01(mocker: MockerFixture) -> None:
     evt.repo.git = mocker.Mock(
         return_value="\n".join(str(p) for p in root.glob("**/*"))
     )
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.create_tasks()
     assert queue.createTask.call_count == 0
 
@@ -144,7 +143,7 @@ def test_create_02(mocker: MockerFixture) -> None:
     evt.branch = "main"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 1
@@ -161,7 +160,7 @@ def test_create_02(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -186,7 +185,7 @@ def test_create_03(mocker: MockerFixture) -> None:
     evt.event_type = "push"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 2
@@ -203,7 +202,7 @@ def test_create_03(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -221,7 +220,7 @@ def test_create_03(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             skip_docker="0",
             source_url=SOURCE_URL,
@@ -249,7 +248,7 @@ def test_create_04(mocker: MockerFixture) -> None:
     evt.branch = "main"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test1"].dirty = True
     sched.services["test2"].dirty = True
     sched.create_tasks()
@@ -267,7 +266,7 @@ def test_create_04(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -287,7 +286,7 @@ def test_create_04(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test2",
             source_url=SOURCE_URL,
             task_group="group",
@@ -310,7 +309,7 @@ def test_create_05(mocker: MockerFixture) -> None:
         return_value="\n".join(str(p) for p in root.glob("**/*"))
     )
     evt.event_type = "release"
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 0
@@ -332,7 +331,7 @@ def test_create_06(mocker: MockerFixture) -> None:
     evt.branch = "push"
     evt.pull_request = None
     evt.http_url = "https://example.com"
-    sched = Scheduler(evt, now, "group", "secret", "push", dry_run=True)
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push", dry_run=True)
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 0
@@ -353,7 +352,7 @@ def test_create_07(mocker: MockerFixture) -> None:
     evt.branch = "push"
     evt.http_url = "https://example.com"
     evt.pull_request = 1
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test1"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 1
@@ -370,7 +369,7 @@ def test_create_07(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test1",
             source_url=SOURCE_URL,
             task_group="group",
@@ -418,7 +417,7 @@ def test_create_08(
     evt.fetch_ref = "fetch"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["testci1"].dirty = ci1_dirty
     sched.services["svc1"].dirty = svc1_dirty
     sched.services["svc2"].dirty = svc2_dirty
@@ -440,7 +439,7 @@ def test_create_08(
                 now=stringDate(now),
                 owner_email=OWNER_EMAIL,
                 provisioner=PROVISIONER_ID,
-                scheduler=SCHEDULER_ID,
+                scheduler="scheduler",
                 service_name="testci1",
                 source_url=SOURCE_URL,
                 task_group="group",
@@ -459,7 +458,7 @@ def test_create_08(
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name=svc,
             source_url=SOURCE_URL,
             task_group="group",
@@ -491,7 +490,7 @@ def test_create_08(
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name=svc,
             source_url=SOURCE_URL,
             task_group="group",
@@ -517,7 +516,7 @@ def test_create_09(mocker: MockerFixture) -> None:
     evt.branch = "main"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test5"].dirty = True
     sched.services["test6"].dirty = True
     sched.services.recipes["withdep.sh"].dirty = True
@@ -536,7 +535,7 @@ def test_create_09(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test5",
             source_url=SOURCE_URL,
             task_group="group",
@@ -555,7 +554,7 @@ def test_create_09(mocker: MockerFixture) -> None:
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
             recipe_name="withdep.sh",
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             source_url=SOURCE_URL,
             task_group="group",
             worker=WORKER_TYPE,
@@ -576,7 +575,7 @@ def test_create_09(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test6",
             source_url=SOURCE_URL,
             task_group="group",
@@ -602,7 +601,7 @@ def test_create_10(mocker: MockerFixture) -> None:
     evt.branch = "main"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["msys-svc"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 1
@@ -618,7 +617,7 @@ def test_create_10(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             setup_sh_path="test-msys/setup.sh",
             service_name="msys-svc",
             source_url=SOURCE_URL,
@@ -643,7 +642,7 @@ def test_create_11(mocker: MockerFixture) -> None:
     evt.branch = "main"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["brew-svc"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 1
@@ -659,7 +658,7 @@ def test_create_11(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="brew-svc",
             setup_sh_path="test-brew/setup.sh",
             source_url=SOURCE_URL,
@@ -685,7 +684,7 @@ def test_create_12(mocker: MockerFixture) -> None:
     evt.fetch_ref = "fetch"
     evt.http_url = "https://example.com"
     evt.pull_request = None
-    sched = Scheduler(evt, now, "group", "secret", "push")
+    sched = Scheduler(evt, now, "group", "scheduler", "secret", "push")
     sched.services["test-svc"].dirty = True
     sched.create_tasks()
     assert queue.createTask.call_count == 1
@@ -701,7 +700,7 @@ def test_create_12(mocker: MockerFixture) -> None:
             now=stringDate(now),
             owner_email=OWNER_EMAIL,
             provisioner=PROVISIONER_ID,
-            scheduler=SCHEDULER_ID,
+            scheduler="scheduler",
             service_name="test-svc",
             source_url=SOURCE_URL,
             task_group="group",


### PR DESCRIPTION
This is the proper fix for https://community-tc.services.mozilla.com/hooks/project-fuzzing/orion-cron .

Propagate the decision task `schedulerId` to the tasks it creates.