### PR TITLE
Use Firefox CI version of grcov instead of building it.

### DIFF
--- a/recipes/linux/grcov.sh
+++ b/recipes/linux/grcov.sh
@@ -16,11 +16,13 @@ source "${0%/*}/common.sh"
 case "${1-install}" in
   install)
     apt-install-auto \
+      binutils \
       ca-certificates \
-      cargo
+      curl \
+      zstd
 
-    cargo install --root /usr grcov
-    strip /usr/bin/grcov
+    retry-curl "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-grcov.latest/artifacts/public/build/grcov.tar.zst" | zstdcat | tar -x -v -C /usr/local/bin grcov
+    strip --strip-unneeded /usr/local/bin/grcov
     ;;
   test)
     grcov --help

--- a/recipes/linux/llvm-symbolizer.sh
+++ b/recipes/linux/llvm-symbolizer.sh
@@ -11,9 +11,7 @@ set -o pipefail
 # shellcheck source=recipes/linux/common.sh
 source "${0%/*}/common.sh"
 
-#### Install LLVM
-
-VERSION=12
+#### Install LLVM Symbolizer
 
 case "${1-install}" in
   install)
@@ -23,7 +21,7 @@ case "${1-install}" in
       curl \
       zstd
 
-    retry-curl "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-clang-${VERSION}.latest/artifacts/public/build/clang.tar.zst" | zstdcat | tar -x -C /usr/local/bin --strip-components=2 clang/bin/llvm-symbolizer
+    retry-curl "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.cache.level-3.toolchains.v3.linux64-llvm-symbolizer.latest/artifacts/public/build/llvm-symbolizer.tar.zst" | zstdcat | tar -x -v -C /usr/local/bin --strip-components=2
     strip --strip-unneeded /usr/local/bin/llvm-symbolizer
     ;;
   test)


### PR DESCRIPTION
In #276 we switched from the Github release binary for grcov to building it, because those binaries require 22.04. Now the cargo in 20.04 is also too old to build grcov.

Although we should update everything to 22.04 at some point, we are using the Firefox-CI toolchains for clang, etc., because then we track the versions used in m-c and they are built to support a range of Linux images.