### PR TITLE
[grizzly-win] Make AV disable commands optional in case the image

### DIFF
--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -21,8 +21,8 @@ status () {
   fi
 }
 
-powershell -ExecutionPolicy Bypass -NoProfile -Command "Set-MpPreference -DisableScriptScanning \$true"
-powershell -ExecutionPolicy Bypass -NoProfile -Command "Set-MpPreference -DisableRealtimeMonitoring \$true"
+powershell -ExecutionPolicy Bypass -NoProfile -Command "Set-MpPreference -DisableScriptScanning \$true" || true
+powershell -ExecutionPolicy Bypass -NoProfile -Command "Set-MpPreference -DisableRealtimeMonitoring \$true" || true
 
 set +x
 retry_curl "$TASKCLUSTER_PROXY_URL/secrets/v1/secret/project/fuzzing/google-logging-creds" | python -c "import json,sys;json.dump(json.load(sys.stdin)['secret']['key'],open('google_logging_creds.json','w'))"


### PR DESCRIPTION
doesn't support them.