### PR TITLE
[grizzly] Use Mesa PPA to work around crash

### DIFF
--- a/services/grizzly/setup.sh
+++ b/services/grizzly/setup.sh
@@ -108,6 +108,13 @@ sys-embed "${packages_with_recommends[@]}"
 retry apt-get install -y -qq "${packages[@]}"
 apt-get remove -y gvfs  # see https://bugzilla.mozilla.org/show_bug.cgi?id=1682934
 
+# install mesa PPA
+# see https://bugzilla.mozilla.org/show_bug.cgi?id=1835691 for details
+# The fix was released as https://docs.mesa3d.org/relnotes/23.1.6.html
+# The fix should be included in Ubuntu 22.04.4 and 23.10 and this can be removed.
+retry add-apt-repository -y ppa:kisak/kisak-mesa -c main -c main/debug
+retry apt-get install -y -qq libgl1-mesa-dri
+
 # We want full symbols for things GTK/Mesa related where we find crashes.
 sys-embed-dbgsym "${dbgsym_packages[@]}"
 


### PR DESCRIPTION
This can be removed once we update to Ubuntu 22.04.4