### PR TITLE
Fetch tags for incremental version calculations

### DIFF
--- a/services/orion-decision/src/orion_decision/git.py
+++ b/services/orion-decision/src/orion_decision/git.py
@@ -138,7 +138,7 @@ class GitRepo:
     def _clone(self, clone_url: Union[Path, str], clone_ref: str, commit: str) -> None:
         self.git("init")
         self.git("remote", "add", "origin", clone_url)
-        self.git("fetch", "-q", "origin", clone_ref, tries=RETRIES)
+        self.git("fetch", "-t", "-q", "origin", clone_ref, tries=RETRIES)
         self.git("-c", "advice.detachedHead=false", "checkout", commit)
 
     def cleanup(self) -> None:


### PR DESCRIPTION
Without this it makes setuptools_scm or poetry-dynamic-versioning unable to calculate a version tag except on releases (where the tag itself is used for `git checkout`), which makes it impossible to test.