### PR TITLE
[libfuzzer] Install libpci3

### DIFF
--- a/services/libfuzzer/setup.sh
+++ b/services/libfuzzer/setup.sh
@@ -39,6 +39,7 @@ packages=(
   less
   libglu1-mesa
   libosmesa6
+  libpci3
   llvm-9
   locales
   nano


### PR DESCRIPTION
In the xpcshell libfuzzer targets, I'm frequently seeing the following error:
`Crash Annotation GraphicsCriticalError: |[0][GFX1-]: glxtest: libpci missing (t=4.55316) [GFX1-]: glxtest: libpci missing`

Adding `libpci-dev` should address this.