### PR TITLE
Remove all symlinks prior to tar

### DIFF
--- a/services/ci-node-14-win/setup.sh
+++ b/services/ci-node-14-win/setup.sh
@@ -36,5 +36,6 @@ rm -rf \
   msys64/usr/share/doc/ \
   msys64/usr/share/info/ \
   msys64/usr/share/man/
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64

--- a/services/ci-node-16-win/setup.sh
+++ b/services/ci-node-16-win/setup.sh
@@ -35,5 +35,6 @@ rm -rf \
   msys64/usr/share/doc/ \
   msys64/usr/share/info/ \
   msys64/usr/share/man/
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64

--- a/services/ci-node-18-win/setup.sh
+++ b/services/ci-node-18-win/setup.sh
@@ -35,5 +35,6 @@ rm -rf \
   msys64/usr/share/doc/ \
   msys64/usr/share/info/ \
   msys64/usr/share/man/
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64

--- a/services/ci-node-20-win/setup.sh
+++ b/services/ci-node-20-win/setup.sh
@@ -35,5 +35,6 @@ rm -rf \
   msys64/usr/share/doc/ \
   msys64/usr/share/info/ \
   msys64/usr/share/man/
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64

--- a/services/ci-py-310-win/setup.sh
+++ b/services/ci-py-310-win/setup.sh
@@ -72,5 +72,6 @@ rm -rf \
 cp -r orion/services/orion-decision orion-decision
 retry python -m pip install ./orion-decision
 cp orion/recipes/linux/py-ci.sh .
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 py-ci.sh pip

--- a/services/ci-py-311-win/setup.sh
+++ b/services/ci-py-311-win/setup.sh
@@ -72,5 +72,6 @@ rm -rf \
 cp -r orion/services/orion-decision orion-decision
 retry python -m pip install ./orion-decision
 cp orion/recipes/linux/py-ci.sh .
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 py-ci.sh pip

--- a/services/ci-py-312-win/setup.sh
+++ b/services/ci-py-312-win/setup.sh
@@ -72,5 +72,6 @@ rm -rf \
 cp -r orion/services/orion-decision orion-decision
 retry python -m pip install ./orion-decision
 cp orion/recipes/linux/py-ci.sh .
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 py-ci.sh pip

--- a/services/ci-py-38-win/setup.sh
+++ b/services/ci-py-38-win/setup.sh
@@ -72,5 +72,6 @@ rm -rf \
 cp -r orion/services/orion-decision orion-decision
 retry python -m pip install ./orion-decision
 cp orion/recipes/linux/py-ci.sh .
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 py-ci.sh pip

--- a/services/ci-py-39-win/setup.sh
+++ b/services/ci-py-39-win/setup.sh
@@ -72,5 +72,6 @@ rm -rf \
 cp -r orion/services/orion-decision orion-decision
 retry python -m pip install ./orion-decision
 cp orion/recipes/linux/py-ci.sh .
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 py-ci.sh pip

--- a/services/grizzly-win/setup.sh
+++ b/services/grizzly-win/setup.sh
@@ -125,5 +125,6 @@ cp orion/services/grizzly-win/launch.sh .
 
 cp -r orion/services/fuzzing-decision fuzzing-decision
 retry python -m pip install ./fuzzing-decision
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 launch.sh pip td-agent-bit

--- a/services/site-scout-win/setup.sh
+++ b/services/site-scout-win/setup.sh
@@ -104,5 +104,6 @@ cp orion/services/site-scout-win/launch.sh .
 
 cp -r orion/services/fuzzing-decision fuzzing-decision
 retry python -m pip install ./fuzzing-decision
-rm -f msys64/etc/mtab
+# Delete symlinks
+find msys64 -type l -delete
 tar -jcvf msys2.tar.bz2 --hard-dereference msys64 launch.sh pip td-agent-bit


### PR DESCRIPTION
Apply #386  to all windows pools. This has only been a problem for bugmon so far, but we don't know why it happened there.