### PR TITLE
[ci-py-win] Remove poetry from setup

### DIFF
--- a/services/ci-py-310-win/setup.sh
+++ b/services/ci-py-310-win/setup.sh
@@ -58,7 +58,6 @@ sed -i "s/^\\(    \\)maker = PipScriptMaker(.*/&\r\n\\1maker.executable = '\\/us
 
 # install utils to match linux ci images
 retry python -m pip install tox
-retry python -m pip install poetry
 retry python -m pip install pre-commit
 retry-curl https://uploader.codecov.io/latest/windows/codecov.exe -o msys64/usr/bin/codecov.exe
 

--- a/services/ci-py-311-win/setup.sh
+++ b/services/ci-py-311-win/setup.sh
@@ -58,7 +58,6 @@ sed -i "s/^\\(    \\)maker = PipScriptMaker(.*/&\r\n\\1maker.executable = '\\/us
 
 # install utils to match linux ci images
 retry python -m pip install tox
-retry python -m pip install poetry
 retry python -m pip install pre-commit
 retry-curl https://uploader.codecov.io/latest/windows/codecov.exe -o msys64/usr/bin/codecov.exe
 

--- a/services/ci-py-312-win/setup.sh
+++ b/services/ci-py-312-win/setup.sh
@@ -58,7 +58,6 @@ sed -i "s/^\\(    \\)maker = PipScriptMaker(.*/&\r\n\\1maker.executable = '\\/us
 
 # install utils to match linux ci images
 retry python -m pip install tox
-retry python -m pip install poetry
 retry python -m pip install pre-commit
 retry-curl https://uploader.codecov.io/latest/windows/codecov.exe -o msys64/usr/bin/codecov.exe
 

--- a/services/ci-py-39-win/setup.sh
+++ b/services/ci-py-39-win/setup.sh
@@ -58,7 +58,6 @@ sed -i "s/^\\(    \\)maker = PipScriptMaker(.*/&\r\n\\1maker.executable = '\\/us
 
 # install utils to match linux ci images
 retry python -m pip install tox
-retry python -m pip install poetry
 retry python -m pip install pre-commit
 retry-curl https://uploader.codecov.io/latest/windows/codecov.exe -o msys64/usr/bin/codecov.exe
 


### PR DESCRIPTION
We have yet to find a way to install poetry cleanly using a portable python instance.  Rather than addressing that directly, we will just install poetry at runtime in any windows CI instance that requires it.