### PR TITLE
[grizzly-win] Compress grizzly working directory to avoid artifact race

### DIFF
--- a/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/task_templates/reduce-windows.yaml
+++ b/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/task_templates/reduce-windows.yaml
@@ -11,8 +11,8 @@ metadata:
 payload:
   artifacts:
     - expires: "${expires}"
-      name: project/fuzzing/grizzly.zip
-      path: grizzly.zip
+      name: project/fuzzing/tmp_grizzly.zip
+      path: tmp_grizzly.zip
       type: file
     - expires: "${expires}"
       name: project/fuzzing/fluentbit.log

--- a/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/task_templates/reduce-windows.yaml
+++ b/services/grizzly-reduce-monitor/src/grizzly_reduce_monitor/task_templates/reduce-windows.yaml
@@ -11,9 +11,9 @@ metadata:
 payload:
   artifacts:
     - expires: "${expires}"
-      name: project/fuzzing/grizzly
-      path: AppData\Local\Temp\grizzly
-      type: directory
+      name: project/fuzzing/grizzly.zip
+      path: grizzly.zip
+      type: file
     - expires: "${expires}"
       name: project/fuzzing/fluentbit.log
       path: td-agent-bit.log

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -143,7 +143,9 @@ echo "sleeping so logs can flush" >&2
 sleep 15
 
 # Archive grizzly working directory
-7z a -tzip grizzly.zip AppData/Local/Temp/grizzly
+if [ -d "AppData/Local/Temp/grizzly" ]; then
+  7z a -tzip grizzly.zip AppData/Local/Temp/grizzly
+fi
 
 case $exit_code in
   5)  # grizzly.session.Session.EXIT_FAILURE (reduce no-repro)

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -141,6 +141,10 @@ exit_code=$?
 echo "returned $exit_code" >&2
 echo "sleeping so logs can flush" >&2
 sleep 15
+
+# Archive grizzly working directory
+7z a -tzip grizzly.zip AppData/Local/Temp/grizzly
+
 case $exit_code in
   5)  # grizzly.session.Session.EXIT_FAILURE (reduce no-repro)
     exit 0

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -133,9 +133,6 @@ cd ..
 status "Setup: installing bearspray"
 retry python -m pip install -e bearspray
 
-# Initialize grizzly working directory
-mkdir -p AppData/Local/Temp/grizzly
-
 status "Setup: launching bearspray"
 set +e
 python -m bearspray "$ADAPTER"
@@ -146,9 +143,7 @@ echo "sleeping so logs can flush" >&2
 sleep 15
 
 # Archive grizzly working directory
-if [ -d "AppData/Local/Temp/grizzly" ]; then
-  7z a -tzip grizzly.zip AppData/Local/Temp/grizzly
-fi
+7z a -tzip tmp_grizzly.zip AppData/Local/Temp/grizzly || touch tmp_grizzly.zip
 
 case $exit_code in
   5)  # grizzly.session.Session.EXIT_FAILURE (reduce no-repro)

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -133,6 +133,9 @@ cd ..
 status "Setup: installing bearspray"
 retry python -m pip install -e bearspray
 
+# Initialize grizzly working directory
+mkdir -p AppData/Local/Temp/grizzly
+
 status "Setup: launching bearspray"
 set +e
 python -m bearspray "$ADAPTER"


### PR DESCRIPTION
It appears that on Windows a race may occur when specifying a directory as an artifact.  See [here](https://community-tc.services.mozilla.com/tasks/K5_NG8pwRRaZAN9MmXs1ZQ/runs/0/logs/public/logs/live.log#L194).  To avoid this, we'll compress the directory first and then attach that as an artifact.