### PR TITLE
[gr-css-reports] Install fuzzfetch

### DIFF
--- a/services/gr-css-reports/launch.sh
+++ b/services/gr-css-reports/launch.sh
@@ -23,6 +23,8 @@ export {GIT_AUTHOR_NAME,GIT_COMMITTER_NAME}="Taskcluster Automation"
 # Install prefpicker
 retry python3 -m pip install git+https://github.com/MozillaSecurity/prefpicker.git
 
+# Install fuzzfetch
+retry python3 -m pip install git+https://github.com/MozillaSecurity/fuzzfetch.git
 # Fetch build
 fuzzfetch -a --fuzzing -n nightly
 


### PR DESCRIPTION
Fuzzfetch was removed from the base image in https://github.com/MozillaSecurity/orion/commit/004f511742efdac3c343d2b1241803e65bfe16f6.