### PR TITLE
Fix git-clone used in py-ci.sh

### DIFF
--- a/recipes/linux/py-ci.sh
+++ b/recipes/linux/py-ci.sh
@@ -45,7 +45,7 @@ clone () {
   git init "$path"
   cd "$path" || exit 1
   git remote add origin "$url"
-  retry git fetch -q --depth=1 origin "${FETCH_REF}"
+  retry git fetch -t -q --depth=1 origin "${FETCH_REF}"
   git -c advice.detachedHead=false checkout "${FETCH_REV}"
 }
 

--- a/services/ci-py-311-osx/setup.sh
+++ b/services/ci-py-311-osx/setup.sh
@@ -4,7 +4,8 @@ set -e -x -o pipefail
 retry () { i=0; while [[ "$i" -lt 9 ]]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
 retry-curl () { curl -sSL --connect-timeout 25 --fail --retry 5 -w "%{stderr}[downloaded %{url_effective}]\n" "$@"; }
 
-retry brew install --force-bottle openssl@3 python@3.11
+retry brew install --force-bottle --overwrite openssl@3 python@3.11
+retry brew postinstall python@3.11
 # shellcheck disable=SC2016
 sed -i '' 's,export PATH=\\",&${HOMEBREW_PREFIX}/opt/python@3.11/libexec/bin:${HOMEBREW_PREFIX}/opt/python@3.11/bin:${HOMEBREW_PREFIX}/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/bin:,' homebrew/Library/Homebrew/cmd/shellenv.sh
 PATH="$HOMEBREW_PREFIX/opt/python@3.11/libexec/bin:$HOMEBREW_PREFIX/opt/python@3.11/bin:$HOMEBREW_PREFIX/opt/python@3.11/Frameworks/Python.framework/Versions/3.11/bin:$PATH"

--- a/services/ci-py-312-osx/setup.sh
+++ b/services/ci-py-312-osx/setup.sh
@@ -4,7 +4,8 @@ set -e -x -o pipefail
 retry () { i=0; while [[ "$i" -lt 9 ]]; do if "$@"; then return; else sleep 30; fi; i="${i+1}"; done; "$@"; }
 retry-curl () { curl -sSL --connect-timeout 25 --fail --retry 5 -w "%{stderr}[downloaded %{url_effective}]\n" "$@"; }
 
-retry brew install --force-bottle openssl@3 python@3.12
+retry brew install --force-bottle --overwrite openssl@3 python@3.12
+retry brew postinstall python@3.12
 # shellcheck disable=SC2016
 sed -i '' 's,export PATH=\\",&${HOMEBREW_PREFIX}/opt/python@3.12/libexec/bin:${HOMEBREW_PREFIX}/opt/python@3.12/bin:${HOMEBREW_PREFIX}/opt/python@3.12/Frameworks/Python.framework/Versions/3.12/bin:,' homebrew/Library/Homebrew/cmd/shellenv.sh
 PATH="$HOMEBREW_PREFIX/opt/python@3.12/libexec/bin:$HOMEBREW_PREFIX/opt/python@3.12/bin:$HOMEBREW_PREFIX/opt/python@3.12/Frameworks/Python.framework/Versions/3.12/bin:$PATH"


### PR DESCRIPTION
This prevents release steps from working (eg. in FuzzManager). We need to fetch tags to be able to check them out.