### PR TITLE
Add worker field to pool configuration

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
@@ -34,7 +34,9 @@ class Provider(ABC):
         assert worker in self.imagesets, f"Missing worker {worker}"
         out: Dict[str, Any] = self.imagesets[worker].get("workerConfig", {})
 
-        if platform == "linux":
+        worker_impl = self.imagesets[worker]["workerImplementation"]
+        LOG.debug("got worker implementation: %s", worker_impl)
+        if platform == "linux" and worker_impl == "docker-worker":
             out.setdefault("dockerConfig", {})
             out.update(
                 {

--- a/services/fuzzing-decision/src/fuzzing_decision/schemas/pools.yaml
+++ b/services/fuzzing-decision/src/fuzzing_decision/schemas/pools.yaml
@@ -131,3 +131,7 @@ properties:
   tasks:
     description: "Number of tasks to run"
     type: integer
+  worker:
+    description: "Taskcluster worker type"
+    type: string
+    pattern: "^d2g|docker|generic$"

--- a/services/fuzzing-decision/tests/fixtures/community/config/imagesets.yml
+++ b/services/fuzzing-decision/tests/fixtures/community/config/imagesets.yml
@@ -3,6 +3,9 @@
 
 docker-worker:
   workerImplementation: docker-worker
+  aws:
+    amis:
+      us-west-1: ami-6789
   gcp:
     image: path/to/image
 

--- a/services/fuzzing-decision/tests/fixtures/pools/expect1.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect1.yml
@@ -28,3 +28,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/expect10.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect10.yml
@@ -31,3 +31,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect11.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect11.yml
@@ -31,3 +31,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect12.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect12.yml
@@ -31,3 +31,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/expect13.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect13.yml
@@ -29,3 +29,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect2.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect2.yml
@@ -32,3 +32,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/expect3.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect3.yml
@@ -33,3 +33,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect4.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect4.yml
@@ -28,3 +28,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect5.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect5.yml
@@ -37,3 +37,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect6.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect6.yml
@@ -37,3 +37,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect7.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect7.yml
@@ -35,3 +35,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/expect8.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect8.yml
@@ -36,3 +36,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/expect9.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/expect9.yml
@@ -30,3 +30,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/load-cfg.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/load-cfg.yml
@@ -16,3 +16,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/pool1.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/pool1.yml
@@ -28,3 +28,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/fixtures/pools/pool4.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/pool4.yml
@@ -28,3 +28,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: generic

--- a/services/fuzzing-decision/tests/fixtures/pools/pool9.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/pool9.yml
@@ -30,3 +30,4 @@ run_as_admin: false
 gpu: false
 demand: false
 nested_virtualization: false
+worker: d2g

--- a/services/fuzzing-decision/tests/fixtures/pools/pre-pool.yml
+++ b/services/fuzzing-decision/tests/fixtures/pools/pre-pool.yml
@@ -22,3 +22,4 @@ macros: {}
 run_as_admin: false
 gpu: false
 nested_virtualization: false
+worker: docker

--- a/services/fuzzing-decision/tests/test_launch.py
+++ b/services/fuzzing-decision/tests/test_launch.py
@@ -65,6 +65,7 @@ def pool_data():
         "macros": {},
         "run_as_admin": False,
         "nested_virtualization": False,
+        "worker": "generic",
     }
 
 
@@ -156,6 +157,7 @@ def test_load_params_4(tmp_path, pool_data):
         "preprocess": None,
         "macros": {"PREPROC": "1"},
         "run_as_admin": False,
+        "worker": "generic",
     }
     with (tmp_path / "test-pool.yml").open("w") as test_cfg:
         yaml.dump(pool_data, stream=test_cfg)


### PR DESCRIPTION
Valid values are [docker, generic, d2g].
`d2g` generates a docker payload with generic worker machine config.