### PR TITLE
Pin base image to Alpine 3.19 for Python 3.11

### DIFF
--- a/services/orion-builder/Dockerfile
+++ b/services/orion-builder/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-FROM alpine:latest
+FROM alpine:3.19
 
 LABEL maintainer Jesse Schwartzentruber <truber@mozilla.com>
 


### PR DESCRIPTION
This is broken in yet another upstream dependency that depends on distutils.

https://community-tc.services.mozilla.com/tasks/ZyTBKqy4SYm2__ZmzS1_NA/runs/0/logs/public/logs/live.log