### PR TITLE
Ignore TASKCLUSTER_NOW and use current time when creating tasks

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
@@ -193,9 +193,7 @@ def cancel_tasks(worker_type: str) -> None:
     queue = taskcluster.get_service("queue")
 
     # cycle only hook fires after this limit
-    cycle_limit = datetime.utcnow().replace(tzinfo=timezone.utc) - timedelta(
-        days=CANCEL_TASK_DAYS
-    )
+    cycle_limit = datetime.now(timezone.utc) - timedelta(days=CANCEL_TASK_DAYS)
 
     # Get tasks by hook
     def iter_tasks_by_hook(hook_id: str):
@@ -421,7 +419,7 @@ class PoolConfiguration(CommonPoolConfiguration):
         self, parent_task_id: str, env: Optional[Dict[str, str]] = None
     ) -> Generator[Tuple[str, Dict], None, None]:
         """Create fuzzing tasks and attach them to a decision task"""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         preprocess_task_id = None
 
         preprocess = cast(PoolConfiguration, self.create_preprocess())
@@ -599,7 +597,7 @@ class PoolConfigMap(CommonPoolConfigMap):
         self, parent_task_id: str, env: Optional[Dict[str, str]] = None
     ) -> Generator[Tuple[str, Dict], None, None]:
         """Create fuzzing tasks and attach them to a decision task"""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         for pool in self.iterpools():
             assert pool.max_run_time is not None

--- a/services/orion-decision/pyproject.toml
+++ b/services/orion-decision/pyproject.toml
@@ -18,6 +18,7 @@ omit = [
 [[tool.mypy.overrides]]
 module = [
     "dockerfile_parse",
+    "freezegun",
     "jsone",
     "jsonschema",
     "setuptools",

--- a/services/orion-decision/src/orion_decision/ci_scheduler.py
+++ b/services/orion-decision/src/orion_decision/ci_scheduler.py
@@ -4,7 +4,7 @@
 """Scheduler for CI tasks"""
 
 import argparse
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import chain
 from json import dumps as json_dump
 from logging import getLogger
@@ -60,7 +60,6 @@ class CIScheduler:
         self,
         project_name: str,
         github_event: GithubEvent,
-        now: datetime,
         task_group: str,
         scheduler_id: str,
         matrix: Dict[str, Any],
@@ -71,7 +70,6 @@ class CIScheduler:
         Arguments:
             project_name: Project name to be used in task metadata.
             github_event: Github event that triggered this run.
-            now: Taskcluster time when decision was triggered.
             task_group: Task group to create tasks in.
             scheduler_id: TC scheduler ID to create tasks in.
             matrix: CI job matrix
@@ -80,7 +78,7 @@ class CIScheduler:
         """
         self.project_name = project_name
         self.github_event = github_event
-        self.now = now
+        self.now = datetime.now(timezone.utc)
         self.task_group = task_group
         self.scheduler_id = scheduler_id
         self.dry_run = dry_run
@@ -262,7 +260,6 @@ class CIScheduler:
             sched = cls(
                 args.project_name,
                 evt,
-                args.now,
                 args.task_group,
                 scheduler_id,
                 args.matrix,

--- a/services/orion-decision/src/orion_decision/cli.py
+++ b/services/orion-decision/src/orion_decision/cli.py
@@ -5,7 +5,6 @@
 
 import argparse
 import sys
-from datetime import datetime
 from locale import LC_ALL, setlocale
 from logging import DEBUG, INFO, WARN, basicConfig, getLogger
 from os import chdir, getenv
@@ -15,7 +14,6 @@ from shutil import which
 from subprocess import run
 from typing import List, Optional
 
-from dateutil.parser import isoparse
 from yaml import safe_load as yaml_load
 
 from .ci_check import check_matrix
@@ -103,13 +101,6 @@ def _define_decision_args(parser: argparse.ArgumentParser) -> None:
         "--scheduler",
         default=None,
         help="Create tasks with this scheduler ID (default: fetch from TaskCluster).",
-    )
-    parser.add_argument(
-        "--now",
-        default=getenv("TASKCLUSTER_NOW", datetime.utcnow().isoformat()),
-        type=isoparse,
-        help="Time reference to calculate task timestamps from ('now' according "
-        "to Taskcluster).",
     )
     parser.add_argument(
         "--dry-run",

--- a/services/orion-decision/tox.ini
+++ b/services/orion-decision/tox.ini
@@ -6,6 +6,7 @@ tox_pip_extensions_ext_venv_update = true
 [testenv:py{38,39,310,311}]
 usedevelop = true
 deps =
+    freezegun
     pytest
     pytest-cov
     pytest-mock


### PR DESCRIPTION
This fixes decision tasks which are pending for longer than 15 minutes.