### PR TITLE
Include default idle timeout for Generic Worker workers

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
@@ -63,6 +63,7 @@ class Provider(ABC):
             out["genericWorker"]["config"].update(
                 {
                     "enableInteractive": True,
+                    "idleTimeoutSecs": 300,
                     "wstAudience": "communitytc",
                     "wstServerURL": (
                         "https://community-websocktunnel.services.mozilla.com"


### PR DESCRIPTION
Really, Generic Worker shouldn't have the crazy default of no timeout, if none is specified. But at the moment, if you don't specify an idle timeout, it won't have one. 5 minutes seems like a reasonable timeout.

Note, we've had some workers running for weeks without claiming tasks, e.g. https://community-tc.services.mozilla.com/provisioners/proj-fuzzing/worker-types/linux-pool51/workers/us-east4-a/299792650250160911?sortBy=started&sortDirection=desc