### PR TITLE
Ensure corpora folder exists in all cases

### DIFF
--- a/services/libfuzzer/libfuzzer.sh
+++ b/services/libfuzzer/libfuzzer.sh
@@ -227,11 +227,11 @@ elif [[ -n "$CORPORA" ]]
 then
   # Use a static corpus instead
   retry svn export --force "$FUZZDATA_URL/$CORPORA" ./corpora/
-else
-  mkdir -p ./corpora
 fi
 
-CORPORA="./corpora/"
+CORPORA=./corpora/
+# ensure corpora folder exists, even if empty
+mkdir -p ./corpora
 
 # %<---[Tokens]---------------------------------------------------------------
 


### PR DESCRIPTION
Since we're passing the full command line args to refresh now, including the non-existent corpora folder, we should make sure it exists.