### PR TITLE
[langfuzz] Add arm64 support

### DIFF
--- a/recipes/linux/js32_deps.sh
+++ b/recipes/linux/js32_deps.sh
@@ -11,23 +11,37 @@ set -o pipefail
 # shellcheck source=recipes/linux/common.sh
 source "${0%/*}/common.sh"
 
-case "${1-install}" in
-  install)
-    dpkg --add-architecture i386
-    sys-update
-    apt-install-auto apt-utils
-    sys-embed libatomic1:i386 libstdc++6:i386 libnspr4:i386
-    ;;
-  test)
-    sys-update
-    "${0%/*}/fuzzfetch.sh"
-    TMPD="$(mktemp -d -p. js32.test.XXXXXXXXXX)"
-    pushd "$TMPD" >/dev/null
-      fuzzfetch --name jsshell --target js --cpu x86
-      ./jsshell/dist/bin/js --help
-    popd >/dev/null
-    rm -rf "$TMPD"
-    "${0%/*}/fuzzfetch.sh" uninstall
-    "${0%/*}/cleanup.sh"
-    ;;
-esac
+if ! is-arm64; then
+  echo "Not arm64. Installing 32 bit packages."
+  packages+=(
+        lib32z1
+        lib32z1-dev
+        libc6-dbg:i386
+        g++-multilib
+        gcc-multilib
+  )
+  case "${1-install}" in
+    install)
+      dpkg --add-architecture i386
+      sys-update
+      apt-install-auto apt-utils
+      sys-embed libatomic1:i386 libstdc++6:i386 libnspr4:i386
+      ;;
+    test)
+      sys-update
+      "${0%/*}/fuzzfetch.sh"
+      TMPD="$(mktemp -d -p. js32.test.XXXXXXXXXX)"
+      pushd "$TMPD" >/dev/null
+        fuzzfetch --name jsshell --target js --cpu x86
+        ./jsshell/dist/bin/js --help
+      popd >/dev/null
+      rm -rf "$TMPD"
+      "${0%/*}/fuzzfetch.sh" uninstall
+      "${0%/*}/cleanup.sh"
+      ;;
+  esac
+else
+  echo "Is arm64. Skipping 32 bit packages."
+  sys-update
+  apt-install-auto apt-utils
+fi

--- a/recipes/linux/js32_deps.sh
+++ b/recipes/linux/js32_deps.sh
@@ -12,14 +12,7 @@ set -o pipefail
 source "${0%/*}/common.sh"
 
 if ! is-arm64; then
-  echo "Not arm64. Installing 32 bit packages."
-  packages+=(
-        lib32z1
-        lib32z1-dev
-        libc6-dbg:i386
-        g++-multilib
-        gcc-multilib
-  )
+  echo "Not arm64. Installing 32 bit packages." >&2
   case "${1-install}" in
     install)
       dpkg --add-architecture i386
@@ -41,7 +34,7 @@ if ! is-arm64; then
       ;;
   esac
 else
-  echo "Is arm64. Skipping 32 bit packages."
+  echo "Is arm64. Skipping 32 bit packages." >&2
   sys-update
   apt-install-auto apt-utils
 fi

--- a/services/langfuzz/setup.sh
+++ b/services/langfuzz/setup.sh
@@ -35,21 +35,15 @@ packages=(
   curl
   creduce
   g++
-  # 32 bit packages, now added in recipes/linux/js32_deps.sh
-  # g++-multilib
-  # gcc-multilib
   gdb
   git
   htop
   jshon
   lbzip2
   less
-  # lib32z1
-  # lib32z1-dev
   libalgorithm-combinatorics-perl
   libbsd-resource-perl
   libc6-dbg
-  # libc6-dbg:i386
   libio-prompt-perl
   libwww-mechanize-perl
   locales
@@ -80,6 +74,17 @@ retry apt-get install -y -qq --no-install-recommends "${packages[@]}"
 
 # Generate locales
 locale-gen en_US.utf8
+
+# Add 32 bit packages for x86-64 (unavailable for arm64)
+if ! is-arm64; then
+  packages+=(
+    lib32z1
+    lib32z1-dev
+    libc6-dbg:i386
+    g++-multilib
+    gcc-multilib
+  )
+fi
 
 # Ensure we retry metadata requests in case of glitches
 # https://github.com/boto/boto/issues/1868

--- a/services/langfuzz/setup.sh
+++ b/services/langfuzz/setup.sh
@@ -68,12 +68,6 @@ packages=(
   zip
   zstd
 )
-retry apt-get install -y -qq --no-install-recommends "${packages[@]}"
-
-#### Base System Configuration
-
-# Generate locales
-locale-gen en_US.utf8
 
 # Add 32 bit packages for x86-64 (unavailable for arm64)
 if ! is-arm64; then
@@ -85,6 +79,13 @@ if ! is-arm64; then
     gcc-multilib
   )
 fi
+
+retry apt-get install -y -qq --no-install-recommends "${packages[@]}"
+
+#### Base System Configuration
+
+# Generate locales
+locale-gen en_US.utf8
 
 # Ensure we retry metadata requests in case of glitches
 # https://github.com/boto/boto/issues/1868

--- a/services/langfuzz/setup.sh
+++ b/services/langfuzz/setup.sh
@@ -35,20 +35,21 @@ packages=(
   curl
   creduce
   g++
-  g++-multilib
-  gcc-multilib
+  # 32 bit packages, now added in recipes/linux/js32_deps.sh
+  # g++-multilib
+  # gcc-multilib
   gdb
   git
   htop
   jshon
   lbzip2
   less
-  lib32z1
-  lib32z1-dev
+  # lib32z1
+  # lib32z1-dev
   libalgorithm-combinatorics-perl
   libbsd-resource-perl
   libc6-dbg
-  libc6-dbg:i386
+  # libc6-dbg:i386
   libio-prompt-perl
   libwww-mechanize-perl
   locales


### PR DESCRIPTION
Starting to add full arm64 linux support for Orion. Tried locally with langfuzz as first example, by removing the irrelevant 32 bit packages (unavailable on arm64).