### PR TITLE
Enable D2G on all worker pools

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
@@ -62,6 +62,7 @@ class Provider(ABC):
             # Fixed config for websocket tunnel
             out["genericWorker"]["config"].update(
                 {
+                    "enableD2G": True,
                     "enableInteractive": True,
                     "wstAudience": "communitytc",
                     "wstServerURL": (


### PR DESCRIPTION
You'll need this change now that we have upgraded to Generic Worker version 70.0.0.