### PR TITLE
Update langfuzz image

### DIFF
--- a/recipes/linux/llvm-symbolizer.sh
+++ b/recipes/linux/llvm-symbolizer.sh
@@ -15,18 +15,22 @@ source "${0%/*}/taskgraph-m-c-latest.sh"
 
 #### Install LLVM Symbolizer
 
-case "${1-install}" in
-  install)
-    apt-install-auto \
-      binutils \
-      ca-certificates \
-      curl \
-      zstd
+if ! is-arm64; then
 
-    retry-curl "$(resolve-tc llvm-symbolizer)" | zstdcat | tar -x -v --strip-components=2 -C /usr/local/bin
-    strip --strip-unneeded /usr/local/bin/llvm-symbolizer
-    ;;
-  test)
-    llvm-symbolizer --version
-    ;;
-esac
+  case "${1-install}" in
+    install)
+      apt-install-auto \
+        binutils \
+        ca-certificates \
+        curl \
+        zstd
+
+      retry-curl "$(resolve-tc llvm-symbolizer)" | zstdcat | tar -x -v --strip-components=2 -C /usr/local/bin
+      strip --strip-unneeded /usr/local/bin/llvm-symbolizer
+      ;;
+    test)
+      llvm-symbolizer --version
+      ;;
+  esac
+
+fi

--- a/services/langfuzz/Dockerfile
+++ b/services/langfuzz/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer Christian Holler <choller@mozilla.com>
 

--- a/services/langfuzz/launch-langfuzz.sh
+++ b/services/langfuzz/launch-langfuzz.sh
@@ -55,6 +55,11 @@ EOF
 
 cd /home/ubuntu
 
+pushd /src/fuzzmanager >/dev/null
+  retry git fetch -q --depth 1 --no-tags origin master
+  git reset --hard origin/master
+popd >/dev/null
+
 # Checkout the configuration with bootstrap script
 retry git clone -v --depth 1 git@langfuzz-config:MozillaSecurity/langfuzz-config.git config
 


### PR DESCRIPTION
- update to Ubuntu 22.04
- pre-install python packages required
- use Amazon Corretto OpenJDK 11
- use gcov 9
- install arm64 grcov & llvm-symbolizer