### PR TITLE
[fuzzing-decision] Reduce queueInactivityTimeout to 5m

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/pool.py
@@ -343,7 +343,7 @@ class PoolConfiguration(CommonPoolConfiguration):
             # give workers 15 minutes to register before assuming they're broken
             "registrationTimeout": parse_time("15m"),
             "reregistrationTimeout": parse_time("4d"),
-            "queueInactivityTimeout": parse_time("2h"),
+            "queueInactivityTimeout": parse_time("5m"),
         }
 
         # Build the decision task payload that will trigger the new fuzzing tasks
@@ -543,7 +543,7 @@ class PoolConfigMap(CommonPoolConfigMap):
             # give workers 15 minutes to register before assuming they're broken
             "registrationTimeout": parse_time("15m"),
             "reregistrationTimeout": parse_time("4d"),
-            "queueInactivityTimeout": parse_time("2h"),
+            "queueInactivityTimeout": parse_time("5m"),
         }
 
         # Build the decision task payload that will trigger the new fuzzing tasks

--- a/services/fuzzing-decision/tests/test_pool.py
+++ b/services/fuzzing-decision/tests/test_pool.py
@@ -226,7 +226,7 @@ def test_aws_resources(
                 }
             ],
             "lifecycle": {
-                "queueInactivityTimeout": 7200,
+                "queueInactivityTimeout": 300,
                 "registrationTimeout": 900,
                 "reregistrationTimeout": 345600,
             },
@@ -379,7 +379,7 @@ def test_azure_resources(
                 },
             ],
             "lifecycle": {
-                "queueInactivityTimeout": 7200,
+                "queueInactivityTimeout": 300,
                 "registrationTimeout": 900,
                 "reregistrationTimeout": 345600,
             },
@@ -546,7 +546,7 @@ def test_gcp_resources(
                 },
             ],
             "lifecycle": {
-                "queueInactivityTimeout": 7200,
+                "queueInactivityTimeout": 300,
                 "registrationTimeout": 900,
                 "reregistrationTimeout": 345600,
             },


### PR DESCRIPTION
The previous queueInactivityTimeout value of 2 hours allowed spot instances to be re-used.  In cases where the previous task wasn't properly cleaned up,the ebs device can fill up prematurely.