### PR TITLE
[fuzzing-decision] Disable OOM abort protection for all fuzzing tasks

### DIFF
--- a/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
+++ b/services/fuzzing-decision/src/fuzzing_decision/decision/providers.py
@@ -62,6 +62,9 @@ class Provider(ABC):
             out.setdefault("genericWorker", {})
             out["genericWorker"].setdefault("config", {})
 
+            # Prevent generic worker from aborting the tasks
+            out["genericWorker"]["config"].setdefault("disableOOMProtection", True)
+
             # Fixed config for websocket tunnel
             out["genericWorker"]["config"].update(
                 {

--- a/services/fuzzing-decision/tests/test_pool.py
+++ b/services/fuzzing-decision/tests/test_pool.py
@@ -274,7 +274,8 @@ def test_aws_resources(
                 "genericWorker": {
                     "config": {
                         "anyKey": "anyValue",
-                        "deploymentId": "d82eac5c561913ee",
+                        "deploymentId": "a5eafce3435543f1",
+                        "disableOOMProtection": True,
                         "wstAudience": "communitytc",
                         "wstServerURL": (
                             "https://community-websocktunnel.services.mozilla.com"
@@ -291,7 +292,7 @@ def test_aws_resources(
                     "d2gConfig": {
                         "enableD2G": True,
                     },
-                    "deploymentId": "37b8e91ebdf4f8c2",
+                    "deploymentId": "4cd453ec4b722b1b",
                 }
             )
 
@@ -380,7 +381,8 @@ def test_azure_resources(
                         "genericWorker": {
                             "config": {
                                 "anyKey": "anyValue",
-                                "deploymentId": "d82eac5c561913ee",
+                                "deploymentId": "a5eafce3435543f1",
+                                "disableOOMProtection": True,
                                 "wstAudience": "communitytc",
                                 "wstServerURL": "https://community-websocktunnel.services.mozilla.com",
                             },


### PR DESCRIPTION
Recent changes to generic worker will abort the task if memory usage exceeds 90% for 5 consecutive measurements at 0.5s intervals.  See https://docs.taskcluster.net/docs/changelog?version=v83.4.0&audience=WORKER-DEPLOYERS for further information.