### PR TITLE
Add support for AFL_PC_FILTER file

### DIFF
--- a/services/nyx/launch-worker.sh
+++ b/services/nyx/launch-worker.sh
@@ -179,6 +179,12 @@ then
   make-copy-commands domino/ > ext_files.sh
 fi
 
+if [[ -n "$AFL_PC_FILTER_FILE_REGEX" ]]
+then
+  python3 /srv/repos/AFLplusplus/utils/dynamic_covfilter/make_symbol_list.py ./firefox/libxul.so > libxul.symbols.txt
+  grep -P "$AFL_PC_FILTER_FILE_REGEX" libxul.symbols.txt > target.symbols.txt
+  echo "export __AFL_PC_FILTER=1" > config.sh
+fi
 
 popd >/dev/null # /home/worker/
 
@@ -269,7 +275,7 @@ else
       echo "could not identify domino strategy from: $NYX_FUZZER" 1>&2
       exit 2
     fi
-    echo "export NYX_FUZZER=\"$NYX_FUZZER\"" > ./sharedir/config.sh
+    echo "export NYX_FUZZER=\"$NYX_FUZZER\"" >> ./sharedir/config.sh
     echo "export STRATEGY=\"${STRATEGY}\"" >> ./sharedir/config.sh
   else
     echo "unknown fuzzer! ($NYX_FUZZER)" 1>&2

--- a/services/nyx/sharedir/fuzz_no_pt.sh
+++ b/services/nyx/sharedir/fuzz_no_pt.sh
@@ -42,6 +42,6 @@ echo "[!] disabling swap" | ./hcat
 swapoff -a
 
 echo "[!] switching user (root -> user)" | ./hcat
-su user -c "sh stage2.sh"
+su user -c "bash stage2.sh"
 
 sleep 200000000

--- a/services/nyx/sharedir/stage2.sh
+++ b/services/nyx/sharedir/stage2.sh
@@ -1,6 +1,8 @@
+#!/usr/bin/env bash
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+set -euo pipefail
 
 echo "[!] executing stage2.sh (as user)" | ./hcat
 
@@ -10,21 +12,21 @@ uname -a | ./hcat
 
 echo "[!] requesting firefox from hypervisor" | ./hcat
 ./hget ff_files.sh ff_files.sh
-sh ff_files.sh
+bash ff_files.sh
 
 echo "[!] requesting config.sh" | ./hcat
 ./hget config.sh config.sh
-. ./config.sh
+source ./config.sh
 
 echo "[!] NYX_FUZZER: $NYX_FUZZER" | ./hcat
-if [ "$(expr "$NYX_FUZZER" : '^Domino')" -gt 0 ]
+if [[ $NYX_FUZZER == Domino* ]]
 then
   echo "[!] requesting extra files from hypervisor" | ./hcat
   ./hget ext_files.sh ext_files.sh
-  sh ext_files.sh
+  bash ext_files.sh
 fi
 
-if [ -n "$MOCHITEST_ARGS" ]
+if [[ -n ${MOCHITEST_ARGS:-} ]]
 then
   echo "[!] requesting testenv.txz from hypervisor" | ./hcat
   ./hget_bulk testenv.txz testenv.txz
@@ -34,18 +36,20 @@ then
   tar xf testenv.txz
   echo "[!] unpacking tools.txz" | ./hcat
   tar xf tools.txz -C tests/bin/
-elif [ "$(expr "$NYX_FUZZER" : '^Domino')" -gt 0 ]
+elif [[ $NYX_FUZZER == Domino* ]]
 then
-  cat >> fuzz.html << EOF
+  cat > fuzz.html <<EOF
 <!DOCTYPE html>
 <meta http-equiv="refresh" content="0; url=http://localhost:8080/nyx_landing.html">
 EOF
 else
-  echo "[!] requesting ${NYX_PAGE-page.zip} from hypervisor" | ./hcat
-  ./hget_bulk "${NYX_PAGE-page.zip}" page.zip
-  echo "[!] unpacking ${NYX_PAGE-page.zip}" | ./hcat
-  unzip "${NYX_PAGE-page.zip}" | ./hcat
-  ln -s "${NYX_PAGE_HTMLNAME-caniuse.html}" fuzz.html
+  zip_name="${NYX_PAGE:-page.zip}"
+  html_name="${NYX_PAGE_HTMLNAME:-caniuse.html}"
+  echo "[!] requesting $zip_name from hypervisor" | ./hcat
+  ./hget_bulk "$zip_name" page.zip
+  echo "[!] unpacking $zip_name" | ./hcat
+  unzip "$zip_name" | ./hcat
+  ln -s "$html_name" fuzz.html
 fi
 
 echo "[!] agent is running in the following path:" | ./hcat
@@ -61,15 +65,15 @@ export AFL_MAP_SIZE=8388608
 export AFL_IGNORE_PROBLEMS=1
 export AFL_IGNORE_PROBLEMS_COVERAGE=1
 export AFL_DEBUG=1
-export MOZ_FUZZ_COVERAGE="${COVERAGE}"
+export MOZ_FUZZ_COVERAGE="${COVERAGE:-}"
 
 echo "[!] Creating firefox profile" | ./hcat
 ./hget prefs.js prefs.js
 LD_LIBRARY_PATH="/home/user/firefox" \
-/home/user/firefox/firefox-bin -CreateProfile test 2>&1 | ./hcat
+xvfb-run /home/user/firefox/firefox-bin -CreateProfile test 2>&1 | ./hcat
 mv prefs.js /home/user/.mozilla/firefox/*test/
 
-if [ "$(expr "$NYX_FUZZER" : '^Domino')" -gt 0 ]
+if [[ $NYX_FUZZER == Domino* ]]
 then
   echo "[!] starting domino web service ($STRATEGY)" | ./hcat
   node /home/user/domino/lib/bin/server.js --is-nyx --strategy "$STRATEGY" &
@@ -83,8 +87,8 @@ export MOZ_FUZZ_LOG_IPC=1
 export NYX_AFL_PLUS_PLUS_MODE=ON
 export NYX_ASAN_EXECUTABLE=TRUE
 export NYX_NET_FUZZ_MODE=ON
-ASAN_OPTIONS="${ASAN_OPTIONS}" \
-UBSAN_OPTIONS="${UBSAN_OPTIONS}" \
+ASAN_OPTIONS="${ASAN_OPTIONS:-}" \
+UBSAN_OPTIONS="${UBSAN_OPTIONS:-}" \
 xvfb-run ./launch.sh /home/user/firefox/firefox-bin -P test --new-window "file:///home/user/fuzz.html" 2>&1 | ./hcat
 
 echo "[!] Debug output:" | ./hcat

--- a/services/nyx/sharedir/stage2.sh
+++ b/services/nyx/sharedir/stage2.sh
@@ -26,6 +26,13 @@ then
   bash ext_files.sh
 fi
 
+if [[ -n ${__AFL_PC_FILTER:-} ]]
+then
+  echo "[!] enabling afl symbol filtering" | ./hcat
+  ./hget target.symbols.txt target.symbols.txt
+  export AFL_PC_FILTER_FILE=/home/user/target.symbols.txt
+fi
+
 if [[ -n ${MOCHITEST_ARGS:-} ]]
 then
   echo "[!] requesting testenv.txz from hypervisor" | ./hcat

--- a/services/nyx/sharedir/stage2.sh
+++ b/services/nyx/sharedir/stage2.sh
@@ -74,7 +74,7 @@ export AFL_IGNORE_PROBLEMS_COVERAGE=1
 export AFL_DEBUG=1
 export MOZ_FUZZ_COVERAGE="${COVERAGE:-}"
 
-echo "[!] Creating firefox profile" | ./hcat
+echo "[!] creating firefox profile" | ./hcat
 ./hget prefs.js prefs.js
 LD_LIBRARY_PATH="/home/user/firefox" \
 xvfb-run /home/user/firefox/firefox-bin -CreateProfile test 2>&1 | ./hcat
@@ -98,8 +98,8 @@ ASAN_OPTIONS="${ASAN_OPTIONS:-}" \
 UBSAN_OPTIONS="${UBSAN_OPTIONS:-}" \
 xvfb-run ./launch.sh /home/user/firefox/firefox-bin -P test --new-window "file:///home/user/fuzz.html" 2>&1 | ./hcat
 
-echo "[!] Debug output:" | ./hcat
+echo "[!] debug output:" | ./hcat
 cat /tmp/data.log* | ./hcat
-echo "[!] Debug output end" | ./hcat
+echo "[!] debug output end" | ./hcat
 
 ./hrelease


### PR DESCRIPTION
Enables dynamic instrumentation filtering.  The image now accepts the `AFL_PC_FILTER_FILE_REGEX` environment variable which defines a regex of symbols to match.

See https://github.com/AFLplusplus/AFLplusplus/blob/f590973387ee04d6c7ef016d5111313f9f4945b8/utils/dynamic_covfilter/README.md for more information.