### PR TITLE
[nyx] Add custom mutator for domino testcases

### DIFF
--- a/services/nyx/Dockerfile
+++ b/services/nyx/Dockerfile
@@ -11,6 +11,7 @@ COPY \
     services/nyx/clang.sh \
     /srv/repos/setup/
 COPY services/nyx/patches/ /srv/repos/setup/patches/
+COPY services/nyx/custom_mutators/ /srv/repos/setup/custom_mutators/
 RUN /srv/repos/setup/build_afl.sh
 
 FROM ubuntu:22.04

--- a/services/nyx/build_afl.sh
+++ b/services/nyx/build_afl.sh
@@ -18,7 +18,10 @@ pkgs=(
   gcc
   git
   libblocksruntime-dev
+  libcurl4-openssl-dev
   libgtk-3-dev
+  libjson-c-dev
+  libssl-dev
   make
   patch
   pax-utils
@@ -64,6 +67,18 @@ git apply /srv/repos/setup/patches/increase-map-size.diff
 make -f GNUmakefile afl-fuzz afl-showmap CODE_COVERAGE=1
 pushd custom_mutators/honggfuzz >/dev/null
 make
+popd >/dev/null
+
+# web services custom mutator
+pushd custom_mutators >/dev/null
+for mutator in /srv/repos/setup/custom_mutators/*
+do
+  dir_name=$(basename "$mutator")
+  cp -r "$mutator" ./
+  pushd "$dir_name" >/dev/null
+  make
+  popd >/dev/null
+done
 popd >/dev/null
 
 pushd nyx_mode >/dev/null

--- a/services/nyx/custom_mutators/web_service_mutator/Makefile
+++ b/services/nyx/custom_mutators/web_service_mutator/Makefile
@@ -1,0 +1,21 @@
+CC = gcc
+CFLAGS = -O3 -funroll-loops -fPIC -Wl,-Bsymbolic
+LDFLAGS = -lcurl -ljson-c -lssl -lcrypto
+INCLUDES = -I../../include/ -I./json -I/usr/include/json-c
+
+OUT = web_service_mutator.so
+
+SRC = web_service_mutator.c
+AFL_SRC = ../../src/afl-performance.c
+
+$(OUT): $(SRC)
+	$(CC) $(CFLAGS) $(INCLUDES) -shared -o $(OUT) $(SRC) $(AFL_SRC) $(LDFLAGS)
+
+debug: CFLAGS += -g -DDEBUG
+debug: $(OUT)
+
+clean:
+	rm -f $(OUT)
+
+install_deps:
+	apt-get install libjson-c-dev libcurl4-openssl-dev libssl-dev

--- a/services/nyx/custom_mutators/web_service_mutator/Makefile
+++ b/services/nyx/custom_mutators/web_service_mutator/Makefile
@@ -1,5 +1,5 @@
-CC = gcc
-CFLAGS = -O3 -funroll-loops -fPIC -Wl,-Bsymbolic
+CC = clang
+CFLAGS = -Wall -Wextra -O3 -funroll-loops -fPIC -Wl,-Bsymbolic
 LDFLAGS = -lcurl -ljson-c -lssl -lcrypto
 INCLUDES = -I../../include/ -I./json -I/usr/include/json-c
 

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -18,7 +18,8 @@ struct memory {
   size_t size;
 };
 
-static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
+static size_t write_callback(void *ptr, size_t size, size_t nmemb,
+                             void *userdata) {
   size_t         realsize = size * nmemb;
   struct memory *mem = userdata;
 
@@ -94,7 +95,8 @@ static uint8_t *decode_buffer_field(json_object *input, size_t *decoded_len) {
 }
 
 static size_t mutate_buffer(MyMutator *data, uint8_t *input, size_t input_size,
-                     uint8_t *add_buf, size_t add_buf_size, size_t max_size) {
+                            uint8_t *add_buf, size_t add_buf_size,
+                            size_t max_size) {
   if (max_size > data->buf_size) {
     uint8_t *ptr = realloc(data->buf, max_size);
     if (!ptr) return 0;
@@ -150,7 +152,7 @@ static json_object *send_to_http_service(const uint8_t *buf, size_t len) {
 }
 
 static char *make_output_json(json_object *response, const uint8_t *mutated,
-                       size_t size) {
+                              size_t size) {
   json_object *output = json_object_new_object();
 
   if (response != NULL) {
@@ -164,6 +166,7 @@ static char *make_output_json(json_object *response, const uint8_t *mutated,
 
   return strdup(json_object_to_json_string(output));
 }
+
 MyMutator *afl_custom_init(afl_state_t *afl) {
   curl_global_init(CURL_GLOBAL_ALL);
   MyMutator *state = malloc(sizeof(MyMutator));

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -1,0 +1,226 @@
+#include "afl-fuzz.h"
+#include "afl-mutations.h"
+#include <curl/curl.h>
+#include <json-c/json.h>
+#include <openssl/evp.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+typedef struct {
+  afl_state_t *afl;
+  uint8_t     *buf;
+  size_t       buf_size;
+} MyMutator;
+
+struct memory {
+  char  *response;
+  size_t size;
+};
+
+size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
+  size_t         realsize = size * nmemb;
+  struct memory *mem = userdata;
+
+  char *ptr_resized = realloc(mem->response, mem->size + realsize + 1);
+  if (!ptr_resized) {
+    perror("Unable to allocate memory for response");
+    return 0;
+  }
+
+  mem->response = ptr_resized;
+
+  memcpy(&(mem->response[mem->size]), ptr, realsize);
+  mem->size += realsize;
+  mem->response[mem->size] = '\0';
+
+  return realsize;
+}
+
+char *base64_encode(const uint8_t *data, size_t len) {
+  size_t out_len = 4 * ((len + 2) / 3);
+  char  *out = malloc(out_len + 1);
+  if (!out) {
+    perror("Memory allocation failed in base64_encode");
+    return NULL;
+  }
+
+  int actual = EVP_EncodeBlock(out, data, len);
+  out[actual] = '\0';
+  return out;
+}
+
+uint8_t *base64_decode(const char *b64, size_t *out_len) {
+  size_t   len = strlen(b64);
+  uint8_t *out = malloc(len);
+  if (!out) {
+    perror("Memory allocation failed in base64_decode");
+    *out_len = 0;
+    return NULL;
+  }
+
+  int decoded_len = EVP_DecodeBlock(out, b64, len);
+  if (decoded_len < 0) {
+    free(out);
+    *out_len = 0;
+    return NULL;
+  }
+  *out_len = decoded_len;
+  return out;
+}
+
+json_object *parse_input_json(const uint8_t *buf, size_t len) {
+  json_object *jobj = json_tokener_parse((const char *)buf);
+  return jobj;
+}
+
+uint8_t *decode_buffer_field(json_object *input, size_t *decoded_len) {
+  json_object *buffer_obj;
+  if (!json_object_object_get_ex(input, "buffer", &buffer_obj) ||
+      json_object_get_type(buffer_obj) != json_type_string) {
+    *decoded_len = 0;
+    return NULL;
+  }
+
+  const char *b64_str = json_object_get_string(buffer_obj);
+  return base64_decode(b64_str, decoded_len);
+}
+
+size_t mutate_buffer(MyMutator *data, uint8_t *input, size_t input_size,
+                     uint8_t *add_buf, size_t add_buf_size, size_t max_size) {
+  if (max_size > data->buf_size) {
+    uint8_t *ptr = realloc(data->buf, max_size);
+    if (!ptr) return 0;
+    data->buf = ptr;
+    data->buf_size = max_size;
+  }
+
+  memcpy(data->buf, input, input_size);
+  bool is_exploration = data->afl->schedule == EXPLORE ? true : false;
+  return afl_mutate(data->afl, data->buf, input_size, rand_below(data->afl, 16),
+                    false, is_exploration, add_buf, add_buf_size, max_size);
+}
+
+json_object *send_to_http_service(const uint8_t *buf, size_t len,
+                                  MyMutator *data) {
+  CURL *curl = curl_easy_init();
+  if (!curl) return NULL;
+
+  struct memory mem;
+  mem.response = malloc(1);
+  mem.size = 0;
+  if (!mem.response) {
+    perror("Unable to allocate memory for HTTP response");
+    curl_easy_cleanup(curl);
+    return NULL;
+  }
+
+  // curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(curl, CURLOPT_URL, "http://localhost:8080/mutate");
+  curl_easy_setopt(curl, CURLOPT_POST, 1L);
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, buf);
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, len);
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &mem);
+
+  struct curl_slist *hs = NULL;
+  hs = curl_slist_append(hs, "Content-Type: application/octet-stream");
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hs);
+
+  CURLcode res = curl_easy_perform(curl);
+  curl_slist_free_all(hs);
+  curl_easy_cleanup(curl);
+
+  if (res != CURLE_OK) {
+    free(mem.response);
+    return NULL;
+  }
+
+  json_object *response_json = json_tokener_parse(mem.response);
+  free(mem.response);
+
+  return response_json;
+}
+
+char *make_output_json(json_object *response, const uint8_t *mutated,
+                       size_t size) {
+  json_object *output = json_object_new_object();
+
+  if (response != NULL) {
+    json_object_object_foreach(response, key, val) {
+      json_object_object_add(output, key, json_object_get(val));
+    }
+  }
+
+  json_object_object_add(output, "buffer",
+                         json_object_new_string(base64_encode(mutated, size)));
+
+  return strdup(json_object_to_json_string(output));
+}
+MyMutator *afl_custom_init(afl_state_t *afl, unsigned int seed) {
+  curl_global_init(CURL_GLOBAL_ALL);
+  MyMutator *state = malloc(sizeof(MyMutator));
+  state->afl = afl;
+  state->buf = malloc(sizeof(uint8_t) * MAX_FILE);
+  state->buf_size = MAX_FILE;
+  return state;
+}
+
+void afl_custom_deinit(MyMutator *data) {
+  if (data) {
+    free(data->buf);
+    free(data);
+    curl_global_cleanup();
+  }
+}
+
+size_t afl_custom_fuzz(MyMutator *data, uint8_t *buf, size_t buf_size,
+                       uint8_t **out_buf, uint8_t *add_buf, size_t add_buf_size,
+                       size_t max_size) {
+  size_t   decoded_len;
+  uint8_t *decoded = NULL;
+
+  json_object *input_json = parse_input_json(buf, buf_size);
+  if (input_json) {
+    decoded = decode_buffer_field(input_json, &decoded_len);
+    if (decoded_len == 0) {
+      perror("Failed to decode buffer field.\n");
+      return 0;
+    }
+  } else {
+    // If the initial buffer isn't in JSON, just treat it as raw data.
+    decoded_len = buf_size;
+    decoded = malloc(buf_size);
+    memcpy(decoded, buf, buf_size);
+  }
+
+  size_t mutated_size = mutate_buffer(data, decoded, decoded_len, add_buf,
+                                      add_buf_size, max_size);
+  if (!mutated_size) {
+    perror("Failed to mutate buffer");
+    free(decoded);
+    return 0;
+  }
+
+  json_object *response = send_to_http_service(data->buf, mutated_size, data);
+  if (!response) {
+    perror("Failed to get a response from HTTP service");
+    free(decoded);
+    return 0;
+  }
+
+  char *output = make_output_json(response, data->buf, mutated_size);
+  free(decoded);
+
+  size_t output_size = strlen(output);
+  if (output_size > max_size) {
+    free(output);
+    return 0;
+  }
+
+  memcpy(data->buf, output, output_size);
+  *out_buf = data->buf;
+  free(output);
+  return output_size;
+}

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -164,7 +164,7 @@ static char *make_output_json(json_object *response, const uint8_t *mutated,
 
   return strdup(json_object_to_json_string(output));
 }
-MyMutator *afl_custom_init(afl_state_t *afl, unsigned int seed) {
+MyMutator *afl_custom_init(afl_state_t *afl) {
   curl_global_init(CURL_GLOBAL_ALL);
   MyMutator *state = malloc(sizeof(MyMutator));
   state->afl = afl;
@@ -209,7 +209,7 @@ size_t afl_custom_fuzz(MyMutator *data, uint8_t *buf, size_t buf_size,
     return 0;
   }
 
-  json_object *response = send_to_http_service(data->buf, mutated_size, data);
+  json_object *response = send_to_http_service(data->buf, mutated_size);
   if (!response) {
     perror("Failed to get a response from HTTP service");
     free(decoded);

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -70,7 +70,14 @@ static uint8_t *base64_decode(const char *b64, size_t *out_len) {
 }
 
 static json_object *parse_input_json(const uint8_t *buf, size_t len) {
-  json_object *jobj = json_tokener_parse((const char *)buf);
+  struct json_tokener *tok = json_tokener_new();
+  if (!tok) {
+    perror("json_tokener_new failed");
+    return NULL;
+  }
+
+  json_object *jobj = json_tokener_parse_ex(tok, (const char *)buf, len);
+  json_tokener_free(tok);
   return jobj;
 }
 

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -59,7 +59,7 @@ static uint8_t *base64_decode(const char *b64, size_t *out_len) {
     return NULL;
   }
 
-  int decoded_len = EVP_DecodeBlock(out, b64, len);
+  int decoded_len = EVP_DecodeBlock(out, (unsigned char *)b64, len);
   if (decoded_len < 0) {
     free(out);
     *out_len = 0;

--- a/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
+++ b/services/nyx/custom_mutators/web_service_mutator/web_service_mutator.c
@@ -18,7 +18,7 @@ struct memory {
   size_t size;
 };
 
-size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
+static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
   size_t         realsize = size * nmemb;
   struct memory *mem = userdata;
 
@@ -37,7 +37,7 @@ size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata) {
   return realsize;
 }
 
-char *base64_encode(const uint8_t *data, size_t len) {
+static char *base64_encode(const uint8_t *data, size_t len) {
   size_t out_len = 4 * ((len + 2) / 3);
   char  *out = malloc(out_len + 1);
   if (!out) {
@@ -45,12 +45,12 @@ char *base64_encode(const uint8_t *data, size_t len) {
     return NULL;
   }
 
-  int actual = EVP_EncodeBlock(out, data, len);
+  int actual = EVP_EncodeBlock((unsigned char *)out, data, len);
   out[actual] = '\0';
   return out;
 }
 
-uint8_t *base64_decode(const char *b64, size_t *out_len) {
+static uint8_t *base64_decode(const char *b64, size_t *out_len) {
   size_t   len = strlen(b64);
   uint8_t *out = malloc(len);
   if (!out) {
@@ -69,12 +69,12 @@ uint8_t *base64_decode(const char *b64, size_t *out_len) {
   return out;
 }
 
-json_object *parse_input_json(const uint8_t *buf, size_t len) {
+static json_object *parse_input_json(const uint8_t *buf, size_t len) {
   json_object *jobj = json_tokener_parse((const char *)buf);
   return jobj;
 }
 
-uint8_t *decode_buffer_field(json_object *input, size_t *decoded_len) {
+static uint8_t *decode_buffer_field(json_object *input, size_t *decoded_len) {
   json_object *buffer_obj;
   if (!json_object_object_get_ex(input, "buffer", &buffer_obj) ||
       json_object_get_type(buffer_obj) != json_type_string) {
@@ -86,7 +86,7 @@ uint8_t *decode_buffer_field(json_object *input, size_t *decoded_len) {
   return base64_decode(b64_str, decoded_len);
 }
 
-size_t mutate_buffer(MyMutator *data, uint8_t *input, size_t input_size,
+static size_t mutate_buffer(MyMutator *data, uint8_t *input, size_t input_size,
                      uint8_t *add_buf, size_t add_buf_size, size_t max_size) {
   if (max_size > data->buf_size) {
     uint8_t *ptr = realloc(data->buf, max_size);
@@ -101,8 +101,7 @@ size_t mutate_buffer(MyMutator *data, uint8_t *input, size_t input_size,
                     false, is_exploration, add_buf, add_buf_size, max_size);
 }
 
-json_object *send_to_http_service(const uint8_t *buf, size_t len,
-                                  MyMutator *data) {
+static json_object *send_to_http_service(const uint8_t *buf, size_t len) {
   CURL *curl = curl_easy_init();
   if (!curl) return NULL;
 
@@ -143,7 +142,7 @@ json_object *send_to_http_service(const uint8_t *buf, size_t len,
   return response_json;
 }
 
-char *make_output_json(json_object *response, const uint8_t *mutated,
+static char *make_output_json(json_object *response, const uint8_t *mutated,
                        size_t size) {
   json_object *output = json_object_new_object();
 

--- a/services/nyx/sharedir/nyx-server.py
+++ b/services/nyx/sharedir/nyx-server.py
@@ -1,0 +1,122 @@
+import base64
+import http.server
+import json
+import mimetypes
+from urllib.parse import urlparse
+
+PORT = 8080
+dynamic_routes: dict[str, tuple[bytes, str]] = {}
+
+NYX_HTML = b"""<html>
+<head>
+  <script>
+    function log(msg) {
+      Nyx.log(`[Domino] (${new Date().toISOString()}) ${msg}`)
+    }
+
+    setTimeout(async () => {
+      try {
+        if (!Nyx.isStarted()) {
+          log("Creating snapshot")
+          Nyx.start()
+
+          log("Fetching buffer")
+          const buffer = Nyx.getRawData()
+          const decoder = new TextDecoder('utf-8')
+          const { entryPoints, resources } = JSON.parse(decoder.decode(buffer))
+
+          const resp = await fetch("/serve", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(resources)
+          })
+
+          if (!resp.ok) {
+            throw new Error(`Web service returned ${resp.status}`)
+          }
+
+          const { fuzzer, objects, timeout } = entryPoints
+          for (url of [fuzzer, objects, timeout]) {
+            const script = document.createElement("script")
+            script.src = `/${url}`
+            script.defer = true
+            log(`Attaching resource: ${url}`)
+            document.body.appendChild(script)
+          }
+        }
+      } catch (e) {
+        log(`Error: ${e.message}`)
+        Nyx.release()
+      }
+    }, 60000)
+  </script>
+</head>
+</html>
+"""
+
+
+class NyxHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        path = urlparse(self.path).path
+
+        if path == "/nyx_landing.html":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(NYX_HTML)))
+            self.end_headers()
+            self.wfile.write(NYX_HTML)
+            return
+
+        if path in dynamic_routes:
+            content, content_type = dynamic_routes[path]
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self) -> None:
+        path = urlparse(self.path).path
+        if path != "/serve":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length)
+
+        try:
+            data = json.loads(body.decode("utf-8"))
+            for filename, b64content in data.items():
+                decoded = base64.b64decode(b64content)
+                mime_type, _ = mimetypes.guess_type(filename)
+                if not mime_type:
+                    mime_type = "application/octet-stream"
+                dynamic_routes[f"/{filename}"] = (decoded, mime_type)
+
+            response = {"registered": list(data.keys())}
+            encoded = json.dumps(response).encode("utf-8")
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        except Exception as e:
+            error = {"error": str(e)}
+            encoded = json.dumps(error).encode("utf-8")
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+
+if __name__ == "__main__":
+    server = http.server.ThreadingHTTPServer(("0.0.0.0", PORT), NyxHandler)
+    print(f"[*] Listening on http://localhost:{PORT}")
+    server.serve_forever()

--- a/services/nyx/sharedir/stage2.sh
+++ b/services/nyx/sharedir/stage2.sh
@@ -22,8 +22,9 @@ echo "[!] NYX_FUZZER: $NYX_FUZZER" | ./hcat
 if [[ $NYX_FUZZER == Domino* ]]
 then
   echo "[!] requesting extra files from hypervisor" | ./hcat
-  ./hget ext_files.sh ext_files.sh
-  bash ext_files.sh
+  ./hget nyx-server.py nyx-server.py
+  echo "[!] starting domino replay server" | ./hcat
+  python3 nyx-server.py &
 fi
 
 if [[ -n ${__AFL_PC_FILTER:-} ]]
@@ -79,12 +80,6 @@ echo "[!] creating firefox profile" | ./hcat
 LD_LIBRARY_PATH="/home/user/firefox" \
 xvfb-run /home/user/firefox/firefox-bin -CreateProfile test 2>&1 | ./hcat
 mv prefs.js /home/user/.mozilla/firefox/*test/
-
-if [[ $NYX_FUZZER == Domino* ]]
-then
-  echo "[!] starting domino web service ($STRATEGY)" | ./hcat
-  node /home/user/domino/lib/bin/server.js --is-nyx --strategy "$STRATEGY" &
-fi
 
 echo "[!] starting firefox" | ./hcat
 ./hget launch.sh launch.sh


### PR DESCRIPTION
Adds a custom mutator for interacting with the domino testcase generator.  This runs in the host and allows us to generate a cache of testcases.  The results are then serialized and passed to each Nyx instance.