### PR TITLE
[recipes] Add curl --retry-all-errors to retry-curl function

### DIFF
--- a/recipes/linux/common.sh
+++ b/recipes/linux/common.sh
@@ -81,7 +81,7 @@ function resolve-url () {
 
 # wrap curl with sane defaults
 function retry-curl () {
-  curl --connect-timeout 25 --fail --location --retry 5 --show-error --silent --write-out "%{stderr}[downloaded %{url_effective}]\n" "$@"
+  curl --connect-timeout 25 --fail --location --retry 5 --retry-all-errors --show-error --silent --write-out "%{stderr}[downloaded %{url_effective}]\n" "$@"
 }
 
 function get-deadline () {


### PR DESCRIPTION
Ensures that all errors, even temporal ones, are retried.