### PR TITLE
[afl] Set AFL_MAP_SIZE AND AFL_PRELOAD for fuzzing and corpus refresh

### DIFF
--- a/services/afl/Dockerfile
+++ b/services/afl/Dockerfile
@@ -29,6 +29,7 @@ COPY \
     services/afl/pyproject.toml \
     services/nyx/nyx_utils.py \
     /srv/repos/nyx_utils/
+COPY services/afl/patches/ /home/worker/patches/
 RUN /srv/repos/setup/setup.sh
 COPY \
     services/afl/launch-root.sh \

--- a/services/afl/launch-worker.sh
+++ b/services/afl/launch-worker.sh
@@ -128,6 +128,8 @@ DAEMON_ARGS=(
 S3_PROJECT="${S3_PROJECT:-afl-$FUZZER}"
 S3_PROJECT_ARGS=(--provider GCS --bucket guided-fuzzing-data --project "$S3_PROJECT")
 
+export AFL_MAP_SIZE=8388608
+
 if [[ -n "$S3_CORPUS_REFRESH" ]]
 then
   update-status "starting corpus refresh"
@@ -159,7 +161,6 @@ else
 
   instance_count="${AFL_INSTANCES:-$(ncpu)}"
   unset AFL_INSTANCES
-  export AFL_MAP_SIZE=8388608
   # run and watch for results
   update-status "launching guided-fuzzing-daemon"
   time xvfb-run guided-fuzzing-daemon "${S3_PROJECT_ARGS[@]}" \

--- a/services/afl/patches/afl-cmin.patch
+++ b/services/afl/patches/afl-cmin.patch
@@ -42,7 +42,7 @@ index a88460a8..e43877ac 100755
      }
    }
  
-+  AFL_PRELOAD = ("AFL_PRELOAD" in ENVIRON) ? ENVIRON["AFL_PRELOAD"] " " : ""
++  AFL_PRELOAD = ("AFL_PRELOAD" in ENVIRON) ? "AFL_PRELOAD=" ENVIRON["AFL_PRELOAD"] " " : ""
 +
    if (0 != system( "test -d "in_dir )) {
      print "[-] Error: directory '"in_dir"' not found." > "/dev/stderr"

--- a/services/afl/patches/afl-cmin.patch
+++ b/services/afl/patches/afl-cmin.patch
@@ -1,0 +1,122 @@
+diff --git a/afl-cmin b/afl-cmin
+index a88460a8..e43877ac 100755
+--- a/afl-cmin
++++ b/afl-cmin
+@@ -258,7 +258,7 @@ BEGIN {
+   # sanity checks
+   if (!prog_args[0] || !in_dir || !out_dir) usage()
+ 
+-  target_bin = prog_args[0] 
++  target_bin = prog_args[0]
+ 
+   # Do a sanity check to discourage the use of /tmp, since we can't really
+   # handle this safely from an awk script.
+@@ -330,14 +330,18 @@ BEGIN {
+     target_bin = tnew
+   }
+ 
+-  if (0 == system ( "grep -aq AFL_DUMP_MAP_SIZE " target_bin )) {
+-    echo "[!] Trying to obtain the map size of the target ..."
+-    get_map_size = "AFL_DUMP_MAP_SIZE=1 " target_bin
+-    get_map_size | getline mapsize
+-    close(get_map_size)
+-    if (mapsize && mapsize > 65535 && mapsize < 100000000) {
+-      AFL_MAP_SIZE = "AFL_MAP_SIZE="mapsize" "
+-      print "[+] Setting "AFL_MAP_SIZE
++  if (!nyx_mode) {
++    if (!ENVIRON["AFL_MAP_SIZE"] && 0 == system ( "grep -aq AFL_DUMP_MAP_SIZE " target_bin )) {
++      echo "[!] Trying to obtain the map size of the target ..."
++      get_map_size = "AFL_DUMP_MAP_SIZE=1 " target_bin
++      get_map_size | getline mapsize
++      close(get_map_size)
++      if (mapsize && mapsize > 65535 && mapsize < 100000000) {
++        AFL_MAP_SIZE = "AFL_MAP_SIZE="mapsize" "
++        print "[+] Setting "AFL_MAP_SIZE
++      }
++    } else {
++      AFL_MAP_SIZE = "AFL_MAP_SIZE=" ENVIRON["AFL_MAP_SIZE"] " "
+     }
+   }
+ 
+@@ -348,6 +352,8 @@ BEGIN {
+     }
+   }
+ 
++  AFL_PRELOAD = ("AFL_PRELOAD" in ENVIRON) ? ENVIRON["AFL_PRELOAD"] " " : ""
++
+   if (0 != system( "test -d "in_dir )) {
+     print "[-] Error: directory '"in_dir"' not found." > "/dev/stderr"
+     exit 1
+@@ -470,10 +476,10 @@ BEGIN {
+     print "[*] Testing the target binary..."
+ 
+     if (!stdin_file) {
+-      system(AFL_MAP_SIZE "AFL_CMIN_ALLOW_ANY=1 "AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"/.run_test\" -Z "extra_par" -- \""target_bin"\" "prog_args_string" <\""in_dir"/"first_file"\"")
++      system(AFL_MAP_SIZE AFL_PRELOAD "AFL_CMIN_ALLOW_ANY=1 "AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"/.run_test\" -Z "extra_par" -- \""target_bin"\" "prog_args_string" <\""in_dir"/"first_file"\"")
+     } else {
+       system("cp \""in_dir"/"first_file"\" "stdin_file)
+-      system(AFL_MAP_SIZE "AFL_CMIN_ALLOW_ANY=1 "AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"/.run_test\" -Z "extra_par" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null")
++      system(AFL_MAP_SIZE AFL_PRELOAD "AFL_CMIN_ALLOW_ANY=1 "AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"/.run_test\" -Z "extra_par" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null")
+     }
+ 
+     first_count = 0
+@@ -537,12 +543,12 @@ BEGIN {
+     for (i = 1; i <= threads; i++) {
+ 
+       if (!stdin_file) {
+-#        print " { "AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -- \""target_bin"\" "prog_args_string"; > "tmpfile"."i".done ; } &"
+-        retval = system(" { "AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -- \""target_bin"\" "prog_args_string"; > "tmpfile"."i".done ; } &")
++#        print " { "AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -- \""target_bin"\" "prog_args_string"; > "tmpfile"."i".done ; } &"
++        retval = system(" { "AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -- \""target_bin"\" "prog_args_string"; > "tmpfile"."i".done ; } &")
+       } else {
+         stdin_file=tmpfile"."i".stdin"
+-#        print " { "AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null; > "tmpfile"."i".done ; } &"
+-        retval = system(" { "AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null; > "tmpfile"."i".done ; } &")
++#        print " { "AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null; > "tmpfile"."i".done ; } &"
++        retval = system(" { "AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -I \""tmpfile"."i"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null; > "tmpfile"."i".done ; } &")
+       }
+     }
+     print "[*] Waiting for parallel tasks to complete ..."
+@@ -562,11 +568,11 @@ BEGIN {
+     if (!stdin_file) {
+       print "    Processing "in_count" files (forkserver mode)..."
+ #      print AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -- \""target_bin"\" "prog_args_string
+-      retval = system(AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -- \""target_bin"\" "prog_args_string)
++      retval = system(AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -- \""target_bin"\" "prog_args_string)
+     } else {
+       print "    Processing "in_count" files (forkserver mode)..."
+ #    print AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null"
+-      retval = system(AFL_MAP_SIZE AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null")
++      retval = system(AFL_MAP_SIZE AFL_PRELOAD AFL_CMIN_ALLOW_ANY AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -H \""stdin_file"\" -- \""target_bin"\" "prog_args_string" </dev/null")
+     }
+ 
+     if (retval && (!AFL_CMIN_CRASHES_ONLY && !AFL_CMIN_ALLOW_ANY)) {
+diff --git a/afl-cmin.bash b/afl-cmin.bash
+index 99ae80d9..2909ebfa 100755
+--- a/afl-cmin.bash
++++ b/afl-cmin.bash
+@@ -245,14 +245,16 @@ if [ "$NYX_MODE" = "" ]; then
+ 
+ fi
+ 
+-grep -aq AFL_DUMP_MAP_SIZE "$TARGET_BIN" && {
+-  echo "[!] Trying to obtain the map size of the target ..."
+-  MAPSIZE=`AFL_DUMP_MAP_SIZE=1 "./$TARGET_BIN" 2>/dev/null`
+-  test -n "$MAPSIZE" && {
+-    export AFL_MAP_SIZE=$MAPSIZE
+-    echo "[+] Setting AFL_MAP_SIZE=$MAPSIZE"
+-  }
+-}
++if [ -z "$NYX_MODE" ]; then
++  if [ -z "$AFL_MAP_SIZE" ] && grep -aq AFL_DUMP_MAP_SIZE "$TARGET_BIN"; then
++    echo "[!] Trying to obtain the map size of the target ..."
++    MAPSIZE=`AFL_DUMP_MAP_SIZE=1 "./$TARGET_BIN" 2>/dev/null`
++    test -n "$MAPSIZE" && {
++      export AFL_MAP_SIZE=$MAPSIZE
++      echo "[+] Setting AFL_MAP_SIZE=$MAPSIZE"
++    }
++  fi
++fi
+ 
+ if [ "$AFL_SKIP_BIN_CHECK" = "" -a "$QEMU_MODE" = "" -a "$FRIDA_MODE" = "" -a "$UNICORN_MODE" = "" -a "$NYX_MODE" = "" ]; then
+ 

--- a/services/afl/setup.sh
+++ b/services/afl/setup.sh
@@ -51,6 +51,7 @@ pkgs=(
   libosmesa6
   libpci3
   openssh-client
+  patch
   pipx
   psmisc
   screen
@@ -81,6 +82,9 @@ afl_ver="$(resolve-tc-alias afl-instrumentation)"
 retry-curl "$(resolve-tc "$afl_ver")" | zstdcat | tar -x -C /opt
 # shellcheck disable=SC2016
 echo 'PATH=$PATH:/opt/afl-instrumentation/bin' >> /etc/bash.bashrc
+pushd /opt/afl-instrumentation/bin
+patch -p1 < /home/worker/patches/afl-cmin.patch
+popd >/dev/null
 
 cd ..
 su worker << EOF


### PR DESCRIPTION
The awk version of afl-cmin does not automatically inherit environment variables.  This PR runs afl-showmap using `AFL_PRELOAD` and `AFL_MAP_SIZE` if they are present in the environment.