### PR TITLE
Minor improvements to Nyx code coverage

### DIFF
--- a/services/nyx/launch-worker.sh
+++ b/services/nyx/launch-worker.sh
@@ -197,11 +197,12 @@ fi
 
 mkdir -p corpus.out
 
+rev="$(grep SourceStamp= sharedir/firefox/platform.ini | cut -d= -f2)"
+
 # download coverage opt build to calculate line-clusters
 if [[ $COVERAGE -eq 1 ]] && [[ ! -e lineclusters.json ]]
 then
   mkdir -p corpus.out/workdir/dump
-  rev="$(grep SourceStamp= sharedir/firefox/platform.ini | cut -d= -f2)"
   retry fuzzfetch -n cov-opt --fuzzing --coverage --build "$rev"
   prefix="$(grep pathprefix cov-opt/firefox.fuzzmanagerconf | cut -d\  -f3-)"
   python3 /srv/repos/ipc-research/ipc-fuzzing/code-coverage/postprocess-gcno.py lineclusters.json cov-opt "$prefix"

--- a/services/nyx/launch-worker.sh
+++ b/services/nyx/launch-worker.sh
@@ -312,6 +312,11 @@ else
     echo "Hello world" > ./corpus/input0
   fi
 
+  if [[ $COVERAGE -eq 1 ]]
+  then
+    export AFL_FAST_CAL=1
+  fi
+
   # run and watch for results
   update-status "launching guided-fuzzing-daemon"
   time guided-fuzzing-daemon "${S3_PROJECT_ARGS[@]}" \

--- a/services/nyx/launch-worker.sh
+++ b/services/nyx/launch-worker.sh
@@ -161,7 +161,7 @@ mkdir -p htools
 cp /srv/repos/ipc-research/ipc-fuzzing/userspace-tools/bin64/h* htools
 cp htools/hget_no_pt .
 
-if [[ -n "$AFL_PC_FILTER_FILE_REGEX" ]]
+if [[ -n "$AFL_PC_FILTER_FILE_REGEX" ]] && [[ -z $COVERAGE ]]
 then
   python3 /srv/repos/AFLplusplus/utils/dynamic_covfilter/make_symbol_list.py ./firefox/libxul.so > libxul.symbols.txt
   grep -P "$AFL_PC_FILTER_FILE_REGEX" libxul.symbols.txt > target.symbols.txt


### PR DESCRIPTION
Currently, the ipc-research code coverage scripts do not work properly when dynamic PC filtering is enabled.  The cause is unknown but dynamic PC filtering is unnecessary for coverage runs regardless.  

This PR:
- disables dynamic filtering for coverage runs
- enables FAST calibration (which improves performance due to the reduced level of stability)
- includes a minor bug fix