### PR TITLE
[grizzly-android] Don't install qemu, android sdk includes its own

### DIFF
--- a/services/grizzly-android/setup.sh
+++ b/services/grizzly-android/setup.sh
@@ -10,7 +10,6 @@ set -x
 source ~worker/.local/bin/common.sh
 
 sys-update
-sys-embed qemu-kvm
 apt-install-auto pipx
 
 PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin retry pipx install fxpoppet


### PR DESCRIPTION
The ubuntu package also creates kvm group, which conflicts with TC kvm permissions.