### PR TITLE
Include logical CPUs when calculating instances to run

### DIFF
--- a/services/fuzzilli/Dockerfile
+++ b/services/fuzzilli/Dockerfile
@@ -28,10 +28,6 @@ COPY \
     services/fuzzilli/setup.sh \
     /srv/repos/setup/
 COPY services/fuzzing-decision /srv/repos/fuzzing-decision
-COPY \
-    services/afl/pyproject.toml \
-    services/nyx/nyx_utils.py \
-    /srv/repos/nyx_utils/
 
 RUN /srv/repos/setup/setup.sh
 COPY services/fuzzilli/coverage.sh \

--- a/services/fuzzilli/fuzzilli.sh
+++ b/services/fuzzilli/fuzzilli.sh
@@ -123,7 +123,7 @@ if [[ -n $TASK_ID ]] || [[ -n $RUN_ID ]]; then
 fi
 
 args=(
-  --instances "${INSTANCES:-$(($(ncpu) / 2))}"
+  --instances "${INSTANCES:-$(python3 -c 'import os;print(len(os.sched_getaffinity(0))/2)')}"
   --project "$S3_PROJECT"
   --stats ./stats
 )

--- a/services/fuzzilli/setup.sh
+++ b/services/fuzzilli/setup.sh
@@ -116,7 +116,6 @@ git-clone "https://github.com/MozillaSecurity/guided-fuzzing-daemon"
 EOF
 
 PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin retry pipx install -e ./guided-fuzzing-daemon
-PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin retry pipx inject --include-apps -e guided-fuzzing-daemon ./nyx_utils
 
 # Cleanup
 "${0%/*}/cleanup.sh"


### PR DESCRIPTION
Otherwise we end up with cpus/4 on x86_64 instead of cpus/2.