### PR TITLE
feat(gr-css): install gr.css globally and update it

### DIFF
--- a/services/gr-css-reports/launch.sh
+++ b/services/gr-css-reports/launch.sh
@@ -15,12 +15,14 @@ chmod 0400 .ssh/*_deploy
 
 export CI=true
 export EMAIL=nobody@community-tc.services.mozilla.com
-export GIT_AUTHOR_NAME="Taskcluster Automation"
-export GIT_COMMITTER_NAME="Taskcluster Automation"
 
 export PATH=$PATH:/home/worker/.local/bin
 # Install prefpicker
 pipx install git+https://github.com/MozillaSecurity/prefpicker.git
+
+# Install gr.css
+npm install -g --prefix /home/worker/.local/ @mozillasecurity/gr.css
+npm update -g --prefix /home/worker/.local/ @mozillasecurity/gr.css
 
 # Fetch build
 retry fuzzfetch -a --fuzzing -n nightly
@@ -31,11 +33,16 @@ git init gr.css.reports
   git remote add origin "${GIT_REPO-git@gr-css-reports:MozillaSecurity/gr.css.reports}"
   retry git fetch -q --depth=10 origin main
   git -c advice.detachedHead=false checkout origin/main
+
+  # Set committer name and email
+  git config user.name "Taskcluster Automation"
+  git config user.email "fuzzing@mozilla.com"
+
   # Ignore the lockfile when installing both to ensure we have the latest
   # version of gr.css and gr.css.generator
   retry npm i
   prefpicker browser-fuzzing.yml prefs.js
-  npx @mozillasecurity/gr.css ~/nightly/firefox src/grammar.json -p prefs.js &&
+  gr.css ~/nightly/firefox src/grammar.json -p prefs.js &&
     npm test &&
     if ! git diff --quiet src/grammar.json; then
       git commit -m "feat(grammar): update grammar" src/grammar.json


### PR DESCRIPTION
Installing gr.css globally outside of the gr.css.reports directory ensures that it will be updated regardless of gr.css.reports dependencies.