### PR TITLE
feat(nyx): allow resuming interrupted corpus preprocessing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: trailing-whitespace
-        exclude_types: [diff]
+        exclude: '\.diff$'
       - id: mixed-line-ending
       - id: name-tests-test
         args: ['--django']

--- a/services/afl/Dockerfile
+++ b/services/afl/Dockerfile
@@ -29,7 +29,7 @@ COPY \
     services/afl/pyproject.toml \
     services/nyx/nyx_utils.py \
     /srv/repos/nyx_utils/
-COPY services/afl/patches/ /home/worker/patches/
+COPY services/nyx/patches/afl-cmin.diff /home/worker/patches/
 RUN /srv/repos/setup/setup.sh
 COPY \
     services/afl/launch-root.sh \

--- a/services/afl/setup.sh
+++ b/services/afl/setup.sh
@@ -84,7 +84,7 @@ retry-curl "$(resolve-tc "$afl_ver")" | zstdcat | tar -x -C /opt
 # shellcheck disable=SC2016
 echo 'PATH=$PATH:/opt/afl-instrumentation/bin' >>/etc/bash.bashrc
 pushd /opt/afl-instrumentation/bin
-patch -p1 </home/worker/patches/afl-cmin.patch
+patch -p1 </home/worker/patches/afl-cmin.diff
 popd >/dev/null
 
 cd ..

--- a/services/nyx/build_afl.sh
+++ b/services/nyx/build_afl.sh
@@ -60,6 +60,9 @@ pushd /srv/repos >/dev/null
 git-clone-rev https://github.com/AFLplusplus/AFLplusplus 78b7e14c73baacf1d88b3c03955e78f5080d17ba
 pushd AFLplusplus >/dev/null
 
+# Enable passing AFL_MAP_SIZE and add resume mode to afl-cmin
+git apply /srv/repos/setup/patches/afl-cmin.diff
+
 # WIP 2-byte chunked variant of honggfuzz custom mutator
 git apply /srv/repos/setup/patches/hongfuzz-2b-chunked.diff
 git apply /srv/repos/setup/patches/increase-map-size.diff

--- a/services/nyx/launch-worker.sh
+++ b/services/nyx/launch-worker.sh
@@ -255,6 +255,11 @@ S3_PROJECT_ARGS=(--project "$S3_PROJECT")
 if [[ -n $S3_CORPUS_REFRESH ]]; then
   update-status "starting corpus refresh"
   export AFL_PRINT_FILENAMES=1
+
+  if [[ $CORPUS_REFRESH_RESUME -eq 1 ]]; then
+    DAEMON_ARGS+=(--corpus-refresh-resume)
+  fi
+
   if [[ $NYX_FUZZER == "IPC_SingleMessage" ]]; then
     guided-fuzzing-daemon --list-projects "${S3_BUCKET_ARGS[@]}" "${S3_PROJECT_ARGS[@]}" | while read -r project; do
       time guided-fuzzing-daemon \

--- a/services/nyx/patches/afl-cmin.diff
+++ b/services/nyx/patches/afl-cmin.diff
@@ -1,17 +1,50 @@
 diff --git a/afl-cmin b/afl-cmin
-index a88460a8..e43877ac 100755
+index a88460a8..32f5b9f0 100755
 --- a/afl-cmin
 +++ b/afl-cmin
-@@ -258,7 +258,7 @@ BEGIN {
-   # sanity checks
-   if (!prog_args[0] || !in_dir || !out_dir) usage()
+@@ -120,6 +120,7 @@ function usage() {
+ "  -A            - allow crashes and timeouts (not recommended)\n" \
+ "  -C            - keep crashing inputs, reject everything else\n" \
+ "  -e            - solve for edge coverage only, ignore hit counts\n" \
++"  -r            - resume a previous minimization run\n" \
+ "\n" \
+ "For additional tips, please consult README.md\n" \
+ "\n" \
+@@ -163,7 +164,7 @@ BEGIN {
+   # process options
+   Opterr = 1    # default is to diagnose
+   Optind = 1    # skip ARGV[0]
+-  while ((_go_c = getopt(ARGC, ARGV, "hi:o:f:m:t:eACOQUXYT:?")) != -1) {
++  while ((_go_c = getopt(ARGC, ARGV, "hi:o:f:m:t:eACOQUXYT:r?")) != -1) {
+     if (_go_c == "i") {
+       if (!Optarg) usage()
+       if (in_dir) { print "Option "_go_c" is only allowed once" > "/dev/stderr"}
+@@ -236,7 +237,11 @@ BEGIN {
+       extra_par = extra_par " -X"
+       nyx_mode = 1
+       continue
+-    } else 
++    } else
++    if (_go_c == "r") {
++      resume_mode = 1
++      continue
++    } else
+     if (_go_c == "?") {
+       exit 1
+     } else 
+@@ -283,6 +288,11 @@ BEGIN {
+     exit 1
+   }
  
--  target_bin = prog_args[0] 
-+  target_bin = prog_args[0]
- 
-   # Do a sanity check to discourage the use of /tmp, since we can't really
-   # handle this safely from an awk script.
-@@ -330,14 +330,18 @@ BEGIN {
++  # Set threads to 1 for resume mode if not already specified
++  if (resume_mode && !threads) {
++    threads = 1
++  }
++
+   if (!threads && !stdin_file && !nyx_mode) {
+     print "[*] Are you aware of the '-T all' parallelize option that improves the speed for large/slow corpuses?"
+   }
+@@ -330,14 +340,18 @@ BEGIN {
      target_bin = tnew
    }
  
@@ -38,7 +71,7 @@ index a88460a8..e43877ac 100755
      }
    }
  
-@@ -348,6 +352,8 @@ BEGIN {
+@@ -348,6 +362,8 @@ BEGIN {
      }
    }
  
@@ -47,7 +80,47 @@ index a88460a8..e43877ac 100755
    if (0 != system( "test -d "in_dir )) {
      print "[-] Error: directory '"in_dir"' not found." > "/dev/stderr"
      exit 1
-@@ -470,10 +476,10 @@ BEGIN {
+@@ -361,15 +377,17 @@ BEGIN {
+   #  in_dir = in_dir "/queue"
+   #}
+ 
+-  system("rm -rf "trace_dir" 2>/dev/null");
+-  system("rm "out_dir"/id[:_]* 2>/dev/null")
++  # system("rm -rf "trace_dir" 2>/dev/null");
++  # system("rm "out_dir"/id[:_]* 2>/dev/null")
+ 
+   cmd = "ls "out_dir"/* 2>/dev/null | wc -l"
+   cmd | getline noofentries
+   close(cmd)
+   if (0 == system( "test -d "out_dir" -a "noofentries" -gt 0" )) {
+-    print "[-] Error: directory '"out_dir"' exists and is not empty - delete it first." > "/dev/stderr"
+-    exit 1
++    if (!resume_mode) {
++      print "[-] Error: directory '"out_dir"' exists and is not empty - delete it first." > "/dev/stderr"
++      exit 1
++    }
+   }
+ 
+   if (threads) {
+@@ -379,7 +397,7 @@ BEGIN {
+     if (threads == "all") {
+       threads = nproc
+     } else {
+-      if (!(threads > 1 && threads <= nproc)) {
++      if (!(threads >= 1 && threads <= nproc)) {
+         print "[-] Error: -T option must be between 1 and "nproc" or \"all\"." > "/dev/stderr"
+         exit 1
+       }
+@@ -449,7 +467,7 @@ BEGIN {
+   in_count = i
+ 
+   first_file = infilesSmallToBigFull[0]
+-  
++
+   #if (0 == system("test -d ""\""in_dir"/"first_file"\"")) {
+   #  print "[-] Error: The input directory is empty or contains subdirectories - please fix." > "/dev/stderr"
+   #  exit 1
+@@ -470,10 +488,10 @@ BEGIN {
      print "[*] Testing the target binary..."
  
      if (!stdin_file) {
@@ -60,7 +133,61 @@ index a88460a8..e43877ac 100755
      }
  
      first_count = 0
-@@ -537,12 +543,12 @@ BEGIN {
+@@ -508,8 +526,32 @@ BEGIN {
+ 
+   if (threads) {
+ 
+-    inputsperfile = int(in_count / threads)
+-    if (in_count % threads) {
++    # Create arrays for chunking - filter if resume mode, otherwise copy all
++    if (resume_mode) {
++      original_count = in_count
++      chunk_count = 0
++      for (i = 0; i < in_count; i++) {
++        trace_file = trace_dir"/"infilesSmallToBig[i]
++        if (0 != system("test -f \""trace_file"\"")) {
++          # Trace file doesn't exist, include this input file for processing
++          chunkSmallToBig[chunk_count] = infilesSmallToBig[i]
++          chunkSmallToBigFull[chunk_count] = infilesSmallToBigFull[i]
++          chunk_count++
++        }
++      }
++      already_processed = original_count - chunk_count
++      print "[*] Resume mode: "chunk_count" files need processing ("already_processed" already processed)."
++    } else {
++      # Copy all files for processing
++      chunk_count = in_count
++      for (i = 0; i < in_count; i++) {
++        chunkSmallToBig[i] = infilesSmallToBig[i]
++        chunkSmallToBigFull[i] = infilesSmallToBigFull[i]
++      }
++    }
++
++    inputsperfile = int(chunk_count / threads)
++    if (chunk_count % threads) {
+       inputsperfile++;
+     }
+ 
+@@ -517,12 +559,14 @@ BEGIN {
+     tmpfile=out_dir "/.filelist"
+     for (instance = 1; instance < threads; instance++) {
+       for (i = 0; i < inputsperfile; i++) {
+-        print in_dir"/"infilesSmallToBigFull[cnt] >> tmpfile"."instance
+-        cnt++
++        if (cnt < chunk_count) {
++          print in_dir"/"chunkSmallToBigFull[cnt] >> tmpfile"."instance
++          cnt++
++        }
+       }
+     }
+-    for (; cnt < in_count; cnt++) {
+-      print in_dir"/"infilesSmallToBigFull[cnt] >> tmpfile"."threads
++    for (; cnt < chunk_count; cnt++) {
++      print in_dir"/"chunkSmallToBigFull[cnt] >> tmpfile"."threads
+     }
+ 
+   }
+@@ -537,12 +581,12 @@ BEGIN {
      for (i = 1; i <= threads; i++) {
  
        if (!stdin_file) {
@@ -77,7 +204,7 @@ index a88460a8..e43877ac 100755
        }
      }
      print "[*] Waiting for parallel tasks to complete ..."
-@@ -562,11 +568,11 @@ BEGIN {
+@@ -562,11 +606,11 @@ BEGIN {
      if (!stdin_file) {
        print "    Processing "in_count" files (forkserver mode)..."
  #      print AFL_CMIN_CRASHES_ONLY"\""showmap"\" -m "mem_limit" -t "timeout" -o \""trace_dir"\" -Z "extra_par" -i \""in_dir"\" -- \""target_bin"\" "prog_args_string
@@ -91,32 +218,3 @@ index a88460a8..e43877ac 100755
      }
  
      if (retval && (!AFL_CMIN_CRASHES_ONLY && !AFL_CMIN_ALLOW_ANY)) {
-diff --git a/afl-cmin.bash b/afl-cmin.bash
-index 99ae80d9..2909ebfa 100755
---- a/afl-cmin.bash
-+++ b/afl-cmin.bash
-@@ -245,14 +245,16 @@ if [ "$NYX_MODE" = "" ]; then
- 
- fi
- 
--grep -aq AFL_DUMP_MAP_SIZE "$TARGET_BIN" && {
--  echo "[!] Trying to obtain the map size of the target ..."
--  MAPSIZE=`AFL_DUMP_MAP_SIZE=1 "./$TARGET_BIN" 2>/dev/null`
--  test -n "$MAPSIZE" && {
--    export AFL_MAP_SIZE=$MAPSIZE
--    echo "[+] Setting AFL_MAP_SIZE=$MAPSIZE"
--  }
--}
-+if [ -z "$NYX_MODE" ]; then
-+  if [ -z "$AFL_MAP_SIZE" ] && grep -aq AFL_DUMP_MAP_SIZE "$TARGET_BIN"; then
-+    echo "[!] Trying to obtain the map size of the target ..."
-+    MAPSIZE=`AFL_DUMP_MAP_SIZE=1 "./$TARGET_BIN" 2>/dev/null`
-+    test -n "$MAPSIZE" && {
-+      export AFL_MAP_SIZE=$MAPSIZE
-+      echo "[+] Setting AFL_MAP_SIZE=$MAPSIZE"
-+    }
-+  fi
-+fi
- 
- if [ "$AFL_SKIP_BIN_CHECK" = "" -a "$QEMU_MODE" = "" -a "$FRIDA_MODE" = "" -a "$UNICORN_MODE" = "" -a "$NYX_MODE" = "" ]; then
- 


### PR DESCRIPTION
Patches afl-cmin and implements an option for resuming an interrupted corpus minimization.  See https://github.com/MozillaSecurity/guided-fuzzing-daemon/pull/85.