### PR TITLE
fix: use PEP 508 direct URL syntax

### DIFF
--- a/services/coverage-revision/Dockerfile
+++ b/services/coverage-revision/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /root
 
 RUN retry () { i=0; while [ $i -lt 9 ]; do if "$@"; then return; else sleep 30; fi; i="$((i+1))"; done; "$@"; } \
     && retry apk add --no-cache bash build-base curl git linux-headers \
-    && retry pip install --disable-pip-version-check --no-cache-dir --progress-bar off "git+https://github.com/MozillaSecurity/fuzzfetch.git#egg=fuzzfetch[sentry]" \
+    && retry pip install --disable-pip-version-check --no-cache-dir --progress-bar off "fuzzfetch[sentry] @ git+https://github.com/MozillaSecurity/fuzzfetch.git" \
     && apk del build-base git linux-headers
 
 COPY recipes/linux/common.sh services/coverage-revision/launch.sh /root/

--- a/services/grizzly-win/launch.sh
+++ b/services/grizzly-win/launch.sh
@@ -83,7 +83,7 @@ EOF
 ./td-agent-bit/bin/fluent-bit.exe -c td-agent-bit.conf &
 
 # ensure we use the latest FM
-retry pip install "git+https://github.com/MozillaSecurity/FuzzManager#egg=FuzzManager[sentry]"
+retry pip install "FuzzManager[sentry] @ git+https://github.com/MozillaSecurity/FuzzManager"
 
 # Get fuzzmanager configuration from TC
 set +x

--- a/services/site-scout-win/launch.sh
+++ b/services/site-scout-win/launch.sh
@@ -116,7 +116,7 @@ EOF
 ./td-agent-bit/bin/fluent-bit.exe -c td-agent-bit.conf &
 
 # ensure we use the latest FM
-retry pip install "git+https://github.com/MozillaSecurity/FuzzManager#egg=FuzzManager[sentry]"
+retry pip install "FuzzManager[sentry] @ git+https://github.com/MozillaSecurity/FuzzManager"
 
 # Get fuzzmanager configuration from TC
 set +x
@@ -137,7 +137,7 @@ chmod 0600 .fuzzmanagerconf
 
 # Install site-scout
 status "Setup: installing site-scout"
-retry python -m pip install "git+https://github.com/MozillaSecurity/fuzzfetch.git#egg=fuzzfetch[sentry]" site-scout
+retry python -m pip install "fuzzfetch[sentry] @ git+https://github.com/MozillaSecurity/fuzzfetch.git" site-scout
 
 # Clone site-scout private
 # only clone if it wasn't already mounted via docker run -v


### PR DESCRIPTION
Added in pip 18.1 (Oct 2018). Non-bare names in egg fragments was removed in pip 26.0 (Jan 2026).